### PR TITLE
Add document management dashboard and hybrid search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,11 @@ ENV/
 env.bak/
 venv.bak/
 
+# Application data directories
+data/
+exports/
+keywords.json
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -1,19 +1,44 @@
-# 📄 Document question answering template
+# 📄 DocuQA 문서 질의응답 대시보드
 
-A simple Streamlit app that answers questions about an uploaded document via OpenAI's GPT-3.5.
+DocuQA는 법률 문서를 업로드하여 구조화된 DB와 벡터 DB로 정리하고, 하이브리드 검색을 통해 질문에 답변해 주는 Streamlit 대시보드입니다. 문서를 업로드하면 자동으로 사례/규칙/개념 데이터를 추출하고, 관리 탭에서 손쉽게 수정하거나 삭제할 수 있습니다.
 
-[![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://document-question-answering-template.streamlit.app/)
+## 🔧 설치 방법
 
-### How to run it on your own machine
+```bash
+pip install -r requirements.txt
+```
 
-1. Install the requirements
+## ▶️ 실행 방법
 
-   ```
-   $ pip install -r requirements.txt
-   ```
+```bash
+streamlit run streamlit_app.py
+```
 
-2. Run the app
+## ✨ 주요 기능
 
-   ```
-   $ streamlit run streamlit_app.py
-   ```
+- **문서 업로드 & DB 재구축**: `data/raw_docs/` 폴더에 업로드한 텍스트/마크다운 문서를 분석하여 SQLite DB와 Chroma 기반의 벡터 DB를 생성합니다.
+- **하이브리드 검색 챗봇**: 키워드 검색과 벡터 유사도 검색을 결합하여 관련 문서를 찾아 요약해 줍니다.
+- **데이터 관리**: 추출된 사례/규칙/개념 데이터를 표 형태로 확인하고 바로 수정하거나 삭제할 수 있습니다.
+
+## 🧾 문서 포맷 예시
+
+파서는 `<사례>`, `<규칙>`, `<개념>` 태그와 `id` 속성을 사용하여 문서를 분리합니다.
+
+```xml
+<사례 id="case-1">
+제목
+내용 ... (규칙: rule-1)
+</사례>
+
+<규칙 id="rule-1">
+제목
+내용 ...
+</규칙>
+```
+
+`(규칙: rule-1, rule-2)` 형식으로 참조하면 자동으로 사례-규칙 연결 테이블이 생성됩니다.
+
+## 🔒 보안 안내
+
+문서, DB, 벡터 저장소 등 민감한 산출물은 `.gitignore`에 등록된 `data/`, `exports/` 경로에 저장되어 버전 관리에서 제외됩니다. 필요 시 `.streamlit/secrets.toml` 또는 환경 변수에 민감한 값을 보관하세요.
+

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the DocuQA Streamlit application."""

--- a/modules/chat_interface.py
+++ b/modules/chat_interface.py
@@ -1,0 +1,92 @@
+"""Streamlit chat interface that leverages the hybrid search engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List
+
+import streamlit as st
+
+from modules.hybrid_search import HybridSearchEngine
+
+
+@dataclass
+class ChatMessage:
+    role: str
+    content: str
+    sources: List[Dict[str, str]] = field(default_factory=list)
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+def _get_search_engine() -> HybridSearchEngine:
+    if "search_engine" not in st.session_state:
+        st.session_state.search_engine = HybridSearchEngine()
+    return st.session_state.search_engine
+
+
+def _format_answer(results: List[Dict[str, str]]) -> str:
+    if not results:
+        return "❌ 관련 결과를 찾지 못했습니다. 다른 키워드로 다시 시도해 보세요."
+
+    lines = ["🔎 검색된 자료 요약:"]
+    for idx, item in enumerate(results[:3], start=1):
+        title = item.get("title") or "제목 없음"
+        snippet = (item.get("content") or "").strip().replace("\n", " ")
+        if len(snippet) > 180:
+            snippet = snippet[:180] + "..."
+        source = item.get("source", "자료")
+        lines.append(f"{idx}. **{title}** ({source}) - {snippet}")
+    lines.append("\n더 자세한 내용은 아래 참고 자료를 확인하세요.")
+    return "\n".join(lines)
+
+
+def render_enhanced_chat() -> None:
+    st.subheader("💬 AI 상담 챗봇")
+
+    if "chat_history" not in st.session_state:
+        st.session_state.chat_history: List[ChatMessage] = []
+
+    col1, col2 = st.columns([1, 0.2])
+    with col1:
+        st.markdown("질문을 입력하면 DB와 벡터 검색을 통해 관련 문서를 찾아 요약합니다.")
+    with col2:
+        if st.button("🧹 대화 초기화"):
+            st.session_state.chat_history = []
+            st.experimental_rerun()
+
+    for message in st.session_state.chat_history:
+        with st.chat_message(message.role):
+            st.markdown(message.content)
+            if message.role == "assistant" and message.sources:
+                with st.expander("📚 참고 자료"):
+                    for idx, src in enumerate(message.sources, start=1):
+                        title = src.get("title") or "제목 없음"
+                        snippet = (src.get("content") or "").strip()
+                        if len(snippet) > 500:
+                            snippet = snippet[:500] + "..."
+                        st.markdown(f"**{idx}. {title}**")
+                        st.write(snippet)
+                        st.caption(src.get("source", "출처 미상"))
+
+    user_input = st.chat_input("질문을 입력하세요")
+    if not user_input:
+        return
+
+    st.session_state.chat_history.append(ChatMessage(role="user", content=user_input))
+    engine = _get_search_engine()
+
+    with st.spinner("지식을 검색하고 있습니다..."):
+        results = engine.search(user_input, top_k=5)
+
+    answer = _format_answer(results)
+    st.session_state.chat_history.append(
+        ChatMessage(role="assistant", content=answer, sources=results)
+    )
+    st.experimental_rerun()
+
+
+def refresh_search_engine() -> None:
+    """Force the cached search engine to reload the vector store."""
+    engine = _get_search_engine()
+    engine.reload_vectorstore()
+

--- a/modules/database.py
+++ b/modules/database.py
@@ -1,0 +1,132 @@
+"""Database helpers for the DocuQA application."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterable
+
+import pandas as pd
+
+DB_PATH = Path("data/suri.db")
+
+DDL: Dict[str, str] = {
+    "cases": (
+        "CREATE TABLE IF NOT EXISTS cases ("
+        "case_id TEXT PRIMARY KEY, "
+        "title TEXT, "
+        "content TEXT"
+        ")"
+    ),
+    "rules": (
+        "CREATE TABLE IF NOT EXISTS rules ("
+        "rule_id TEXT PRIMARY KEY, "
+        "title TEXT, "
+        "content TEXT"
+        ")"
+    ),
+    "concepts": (
+        "CREATE TABLE IF NOT EXISTS concepts ("
+        "concept_id TEXT PRIMARY KEY, "
+        "title TEXT, "
+        "content TEXT"
+        ")"
+    ),
+    "case_rules_link": (
+        "CREATE TABLE IF NOT EXISTS case_rules_link ("
+        "case_id TEXT, "
+        "rule_id TEXT, "
+        "PRIMARY KEY (case_id, rule_id)"
+        ")"
+    ),
+}
+
+PRIMARY_KEYS: Dict[str, str] = {
+    "cases": "case_id",
+    "rules": "rule_id",
+    "concepts": "concept_id",
+}
+
+
+def ensure_data_folder() -> None:
+    """Create the directory that stores the SQLite database if required."""
+    os.makedirs(DB_PATH.parent, exist_ok=True)
+
+
+@contextmanager
+def get_connection() -> Iterable[sqlite3.Connection]:
+    """Context manager that yields a SQLite connection with foreign keys enabled."""
+    ensure_data_folder()
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        yield conn
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    """Initialise the SQLite schema if it does not exist yet."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        for ddl in DDL.values():
+            cur.execute(ddl)
+        conn.commit()
+
+
+def write_tables(tables: Dict[str, pd.DataFrame]) -> None:
+    """Persist the provided data frames into the SQLite database."""
+    if not tables:
+        return
+
+    init_db()
+    with get_connection() as conn:
+        for table, df in tables.items():
+            if df is None:
+                continue
+            df.to_sql(table, conn, if_exists="replace", index=False)
+
+
+def fetch_table(table: str) -> pd.DataFrame:
+    """Return the contents of a table including the SQLite rowid for editing."""
+    if table not in DDL:
+        raise ValueError(f"Unknown table: {table}")
+
+    with get_connection() as conn:
+        query = f"SELECT rowid, * FROM {table} ORDER BY rowid"
+        return pd.read_sql_query(query, conn)
+
+
+def update_record(table: str, identifier: str, *, title: str, content: str) -> None:
+    """Update the title/content columns for a given record."""
+    pk_column = PRIMARY_KEYS.get(table)
+    if not pk_column:
+        raise ValueError(f"Table '{table}' does not support editing")
+
+    with get_connection() as conn:
+        conn.execute(
+            f"UPDATE {table} SET title = ?, content = ? WHERE {pk_column} = ?",
+            (title, content, identifier),
+        )
+        conn.commit()
+
+
+def delete_record(table: str, identifier: str) -> None:
+    """Remove a record from the specified table."""
+    pk_column = PRIMARY_KEYS.get(table)
+    if not pk_column:
+        raise ValueError(f"Table '{table}' does not support deletion")
+
+    with get_connection() as conn:
+        conn.execute(
+            f"DELETE FROM {table} WHERE {pk_column} = ?",
+            (identifier,),
+        )
+        conn.commit()
+
+
+def list_available_tables() -> Iterable[str]:
+    """Return the list of logical tables managed by the application."""
+    return tuple(DDL.keys())
+

--- a/modules/hybrid_search.py
+++ b/modules/hybrid_search.py
@@ -1,0 +1,98 @@
+"""Hybrid search that combines SQLite keyword search with vector similarity."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, List
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_chroma import Chroma
+
+from modules.database import DB_PATH
+
+VECTOR_DB_DIR = Path("data/vector_db")
+EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+
+SQL_QUERIES: Dict[str, str] = {
+    "cases": "SELECT case_id as identifier, title, content FROM cases WHERE title LIKE ? OR content LIKE ?",
+    "rules": "SELECT rule_id as identifier, title, content FROM rules WHERE title LIKE ? OR content LIKE ?",
+    "concepts": "SELECT concept_id as identifier, title, content FROM concepts WHERE title LIKE ? OR content LIKE ?",
+}
+
+
+class HybridSearchEngine:
+    """Combine relational and vector search for richer answers."""
+
+    def __init__(self) -> None:
+        self.embeddings = None
+        self.vectorstore = None
+        self.reload_vectorstore()
+
+    def reload_vectorstore(self) -> None:
+        """(Re-)initialise the persisted Chroma vector store if it exists."""
+        if VECTOR_DB_DIR.exists():
+            self.embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+            self.vectorstore = Chroma(
+                persist_directory=str(VECTOR_DB_DIR),
+                embedding_function=self.embeddings,
+            )
+        else:
+            self.embeddings = None
+            self.vectorstore = None
+
+    def search(self, query: str, top_k: int = 5) -> List[Dict[str, str]]:
+        query = query.strip()
+        if not query:
+            return []
+
+        results: List[Dict[str, str]] = []
+        results.extend(self._search_sqlite(query, limit=top_k))
+        results.extend(self._search_vector(query, k=top_k))
+
+        deduped: List[Dict[str, str]] = []
+        seen = set()
+        for item in results:
+            key = (item.get("source"), item.get("title"), item.get("content"))
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(item)
+        return deduped
+
+    def _search_sqlite(self, query: str, limit: int = 5) -> List[Dict[str, str]]:
+        if not DB_PATH.exists():
+            return []
+
+        pattern = f"%{query}%"
+        matches: List[Dict[str, str]] = []
+        with sqlite3.connect(DB_PATH) as conn:
+            for table, sql in SQL_QUERIES.items():
+                cur = conn.execute(sql + " LIMIT ?", (pattern, pattern, limit))
+                rows = cur.fetchall()
+                for identifier, title, content in rows:
+                    matches.append(
+                        {
+                            "id": identifier,
+                            "title": title,
+                            "content": content,
+                            "source": f"SQLite::{table}",
+                        }
+                    )
+        return matches
+
+    def _search_vector(self, query: str, k: int = 5) -> List[Dict[str, str]]:
+        if not self.vectorstore:
+            return []
+
+        docs = self.vectorstore.similarity_search(query, k=k)
+        results: List[Dict[str, str]] = []
+        for doc in docs:
+            results.append(
+                {
+                    "id": doc.metadata.get("id"),
+                    "title": doc.metadata.get("title", ""),
+                    "content": doc.page_content,
+                    "source": doc.metadata.get("source", "Vector DB"),
+                }
+            )
+        return results
+

--- a/modules/parser.py
+++ b/modules/parser.py
@@ -1,0 +1,198 @@
+"""Utilities for parsing raw legal documents into structured datasets."""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import pandas as pd
+from langchain.docstore.document import Document
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_chroma import Chroma
+
+from modules.database import PRIMARY_KEYS, write_tables
+
+RAW_DOCS_DIR = Path("data/raw_docs")
+VECTOR_DB_DIR = Path("data/vector_db")
+EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+
+TAG_TO_TABLE = {
+    "사례": "cases",
+    "규칙": "rules",
+    "개념": "concepts",
+}
+
+
+@dataclass
+class BuildResult:
+    """Return value for :func:`build_databases`."""
+
+    success: bool
+    message: str
+    counts: Dict[str, int] = field(default_factory=dict)
+
+
+def _iter_raw_files() -> Iterable[Path]:
+    """Yield raw document files supported by the parser."""
+    RAW_DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    patterns = ["*.txt", "*.md"]
+    for pattern in patterns:
+        for path in RAW_DOCS_DIR.glob(pattern):
+            if path.is_file():
+                yield path
+
+
+def parse_text_to_chunks(text: str) -> List[Dict[str, str]]:
+    """Split the provided raw text into tagged chunks."""
+    chunks: List[Dict[str, str]] = []
+    pattern = r"<(사례|규칙|개념)([^>]*)>(.*?)</\\1>"
+    for match in re.finditer(pattern, text, re.DOTALL):
+        tag = match.group(1)
+        attrs = match.group(2)
+        body = match.group(3)
+        id_match = re.search(r'id="([^"]+)"', attrs)
+        if not id_match:
+            continue
+        chunk_id = id_match.group(1).strip()
+        content = re.sub(r"<[^>]+>", "", body).strip()
+        title = content.splitlines()[0].strip() if content else chunk_id
+        chunks.append(
+            {
+                "id": chunk_id,
+                "type": tag,
+                "title": title,
+                "content": content,
+            }
+        )
+    return chunks
+
+
+def process_chunks_to_tables(chunks: List[Dict[str, str]]) -> Dict[str, pd.DataFrame]:
+    """Organise chunk dictionaries into per-table data frames."""
+    cases: List[Dict[str, str]] = []
+    rules: List[Dict[str, str]] = []
+    concepts: List[Dict[str, str]] = []
+    links: List[Dict[str, str]] = []
+
+    for chunk in chunks:
+        table = TAG_TO_TABLE.get(chunk["type"])
+        if table == "cases":
+            cases.append(
+                {
+                    "case_id": chunk["id"],
+                    "title": chunk["title"],
+                    "content": chunk["content"],
+                }
+            )
+            for link in _extract_rule_links(chunk["content"], chunk["id"]):
+                links.append(link)
+        elif table == "rules":
+            rules.append(
+                {
+                    "rule_id": chunk["id"],
+                    "title": chunk["title"],
+                    "content": chunk["content"],
+                }
+            )
+        elif table == "concepts":
+            concepts.append(
+                {
+                    "concept_id": chunk["id"],
+                    "title": chunk["title"],
+                    "content": chunk["content"],
+                }
+            )
+
+    return {
+        "cases": pd.DataFrame(cases, columns=["case_id", "title", "content"]),
+        "rules": pd.DataFrame(rules, columns=["rule_id", "title", "content"]),
+        "concepts": pd.DataFrame(concepts, columns=["concept_id", "title", "content"]),
+        "case_rules_link": pd.DataFrame(links, columns=["case_id", "rule_id"]),
+    }
+
+
+def _extract_rule_links(content: str, case_id: str) -> List[Dict[str, str]]:
+    """Helper to map rule ids referenced in a case to link rows."""
+    match = re.search(r"\(규칙:\s*([^\)]+)\)", content)
+    if not match:
+        return []
+    rule_ids = [item.strip() for item in match.group(1).split(",") if item.strip()]
+    return [{"case_id": case_id, "rule_id": rule_id} for rule_id in rule_ids]
+
+
+def _deduplicate_chunks(chunks: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Remove duplicated chunk IDs while keeping the first occurrence."""
+    seen = set()
+    unique_chunks: List[Dict[str, str]] = []
+    for chunk in chunks:
+        if chunk["id"] in seen:
+            continue
+        seen.add(chunk["id"])
+        unique_chunks.append(chunk)
+    return unique_chunks
+
+
+def _build_vector_store(documents: Iterable[Document]) -> None:
+    """Persist the provided documents into a Chroma vector database."""
+    docs = list(documents)
+    if not docs:
+        return
+
+    embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+    if VECTOR_DB_DIR.exists():
+        shutil.rmtree(VECTOR_DB_DIR)
+    Chroma.from_documents(docs, embeddings, persist_directory=str(VECTOR_DB_DIR))
+
+
+def build_databases() -> BuildResult:
+    """Parse raw documents, refresh the SQLite DB and rebuild the vector store."""
+    try:
+        files = list(_iter_raw_files())
+        if not files:
+            return BuildResult(False, "raw_docs 폴더에 처리할 문서가 없습니다.")
+
+        chunks: List[Dict[str, str]] = []
+        for path in files:
+            with path.open("r", encoding="utf-8") as handle:
+                chunks.extend(parse_text_to_chunks(handle.read()))
+
+        if not chunks:
+            return BuildResult(False, "문서에서 유효한 태그를 찾지 못했습니다.")
+
+        unique_chunks = _deduplicate_chunks(chunks)
+        tables = process_chunks_to_tables(unique_chunks)
+        write_tables(tables)
+
+        documents = []
+        for table_name, df in tables.items():
+            if table_name == "case_rules_link" or df.empty:
+                continue
+            for _, row in df.iterrows():
+                metadata = {"source": table_name, "title": row.get("title", "")}
+                pk = PRIMARY_KEYS.get(table_name)
+                if pk and pk in row:
+                    metadata["id"] = row[pk]
+                lines = []
+                for col in df.columns:
+                    value = row.get(col)
+                    if pd.notna(value):
+                        lines.append(f"{col}: {value}")
+                documents.append(
+                    Document(page_content="\n".join(lines), metadata=metadata)
+                )
+        _build_vector_store(documents)
+
+        counts = {name: int(len(df)) for name, df in tables.items() if df is not None}
+        return BuildResult(True, "DB 및 벡터 DB 재구축을 완료했습니다.", counts)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        return BuildResult(False, f"처리 중 오류가 발생했습니다: {exc}")
+
+
+def list_raw_documents() -> List[Path]:
+    """Return a sorted list of raw document paths available for processing."""
+    return sorted(_iter_raw_files())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 streamlit
-openai
+pandas
+langchain
+langchain-community
+langchain-chroma
+sentence-transformers

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,53 +1,131 @@
+"""DocuQA Streamlit dashboard for managing legal documents and Q&A."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
 import streamlit as st
-from openai import OpenAI
 
-# Show title and description.
-st.title("📄 Document question answering")
-st.write(
-    "Upload a document below and ask a question about it – GPT will answer! "
-    "To use this app, you need to provide an OpenAI API key, which you can get [here](https://platform.openai.com/account/api-keys). "
-)
+from modules.chat_interface import refresh_search_engine, render_enhanced_chat
+from modules.database import DB_PATH, PRIMARY_KEYS, delete_record, fetch_table, update_record
+from modules.parser import BuildResult, build_databases, list_raw_documents
 
-# Ask user for their OpenAI API key via `st.text_input`.
-# Alternatively, you can store the API key in `./.streamlit/secrets.toml` and access it
-# via `st.secrets`, see https://docs.streamlit.io/develop/concepts/connections/secrets-management
-openai_api_key = st.text_input("OpenAI API Key", type="password")
-if not openai_api_key:
-    st.info("Please add your OpenAI API key to continue.", icon="🗝️")
-else:
+RAW_DOC_DIR = Path("data/raw_docs")
+RAW_DOC_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Create an OpenAI client.
-    client = OpenAI(api_key=openai_api_key)
+st.set_page_config(page_title="DocuQA", layout="wide")
+st.title("🔮 DocuQA 문서 관리 & 질의응답")
 
-    # Let the user upload a file via `st.file_uploader`.
-    uploaded_file = st.file_uploader(
-        "Upload a document (.txt or .md)", type=("txt", "md")
-    )
 
-    # Ask the user for a question via `st.text_area`.
-    question = st.text_area(
-        "Now ask a question about the document!",
-        placeholder="Can you give me a short summary?",
-        disabled=not uploaded_file,
-    )
+def _save_uploaded_files(uploaded_files) -> None:
+    for uploaded_file in uploaded_files:
+        destination = RAW_DOC_DIR / uploaded_file.name
+        destination.write_bytes(uploaded_file.getbuffer())
 
-    if uploaded_file and question:
 
-        # Process the uploaded file and question.
-        document = uploaded_file.read().decode()
-        messages = [
+def _render_build_summary(result: BuildResult) -> None:
+    if not result.counts:
+        return
+    summary = {table: int(count) for table, count in result.counts.items()}
+    st.json(summary)
+
+
+def _render_raw_document_overview() -> None:
+    docs = list_raw_documents()
+    if not docs:
+        st.info("현재 raw_docs 폴더에 저장된 문서가 없습니다.")
+        return
+
+    data = []
+    for path in docs:
+        stats = path.stat()
+        data.append(
             {
-                "role": "user",
-                "content": f"Here's a document: {document} \n\n---\n\n {question}",
+                "파일명": path.name,
+                "크기(KB)": round(stats.st_size / 1024, 1),
+                "수정일": datetime.fromtimestamp(stats.st_mtime).strftime("%Y-%m-%d %H:%M"),
             }
-        ]
-
-        # Generate an answer using the OpenAI API.
-        stream = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=messages,
-            stream=True,
         )
+    st.dataframe(pd.DataFrame(data), hide_index=True, use_container_width=True)
 
-        # Stream the response to the app using `st.write_stream`.
-        st.write_stream(stream)
+
+def _render_document_editor(table: str) -> None:
+    try:
+        df = fetch_table(table)
+    except ValueError as exc:
+        st.error(str(exc))
+        return
+
+    if df.empty:
+        st.info("선택한 테이블에 데이터가 없습니다.")
+        return
+
+    st.dataframe(df.drop(columns=["rowid"]), use_container_width=True, hide_index=True, height=400)
+
+    pk_column = PRIMARY_KEYS.get(table)
+    id_options = df[pk_column].tolist()
+    selection = st.selectbox(
+        "수정할 항목 선택",
+        options=id_options,
+        format_func=lambda value: f"{value} - {df.loc[df[pk_column] == value, 'title'].iat(0)}",
+    )
+
+    record = df.loc[df[pk_column] == selection].iloc[0]
+    new_title = st.text_input("제목", value=record.get("title", ""))
+    new_content = st.text_area("내용", value=record.get("content", ""), height=220)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        if st.button("💾 저장", key=f"save_{table}_{selection}"):
+            update_record(table, selection, title=new_title, content=new_content)
+            st.success("저장되었습니다.")
+            st.experimental_rerun()
+    with col2:
+        if st.button("🗑️ 삭제", key=f"delete_{table}_{selection}"):
+            delete_record(table, selection)
+            st.warning("삭제되었습니다.")
+            st.experimental_rerun()
+
+
+tab_upload, tab_chat, tab_manage = st.tabs(["📂 문서 업로드 & DB", "💬 질의응답", "📊 데이터 관리"])
+
+with tab_upload:
+    st.subheader("문서 업로드 및 데이터베이스 재구축")
+
+    uploaded_files = st.file_uploader(
+        "문서를 업로드하세요 (txt/md)",
+        type=["txt", "md"],
+        accept_multiple_files=True,
+    )
+    if uploaded_files:
+        _save_uploaded_files(uploaded_files)
+        st.success(f"{len(uploaded_files)}개의 문서를 저장했습니다. DB 재구축을 진행하세요.")
+
+    rebuild = st.button("🛠 DB 재구축")
+    if rebuild:
+        result = build_databases()
+        if result.success:
+            st.success(result.message)
+            _render_build_summary(result)
+            refresh_search_engine()
+        else:
+            st.error(result.message)
+        st.session_state["last_build_result"] = result
+    elif "last_build_result" in st.session_state:
+        st.caption(f"마지막 재구축: {st.session_state['last_build_result'].message}")
+
+    st.markdown("### 저장된 원본 문서")
+    _render_raw_document_overview()
+
+with tab_chat:
+    render_enhanced_chat()
+
+with tab_manage:
+    st.subheader("정제된 데이터 조회 및 수정")
+    if not DB_PATH.exists():
+        st.info("DB가 아직 생성되지 않았습니다. 먼저 문서를 업로드하고 재구축하세요.")
+    else:
+        options = list(PRIMARY_KEYS.keys())
+        table = st.selectbox("조회할 테이블 선택", options=options)
+        _render_document_editor(table)


### PR DESCRIPTION
## Summary
- add modular database, parser, hybrid search, and chat interface helpers for document processing
- replace the Streamlit entrypoint with a multi-tab document management dashboard that supports upload, rebuild, chat, and inline edits
- document the new workflow and ignore generated data directories for security

## Testing
- python -m compileall streamlit_app.py modules
- pip install -r requirements.txt *(fails: blocked by proxy while downloading langchain)*

------
https://chatgpt.com/codex/tasks/task_e_68c98f80b4e0833096fc944cad7be4b4