### PR TITLE
Restore parsing helpers for RAG imports

### DIFF
--- a/streamlit_app_fixed/core/parsing.py
+++ b/streamlit_app_fixed/core/parsing.py
@@ -1,31 +1,174 @@
-import pandas as pd
 import os
+from typing import Dict, List, Optional, Tuple
 
-def parse_and_store_documents(file_path: str):
+import pandas as pd
+
+
+ParsedSection = Dict[str, str]
+
+
+def parse_document(text: str) -> Tuple[List[ParsedSection], List[ParsedSection], List[ParsedSection]]:
+    """간단한 규칙 기반 문서 파서.
+
+    텍스트를 사례(case), 규칙(rule), 개념(concept) 세 가지 범주로 나누어
+    각 항목의 제목과 설명을 추출한다. 명시적인 구분자가 없을 경우에는
+    일반 텍스트를 개념으로 처리하여 반환한다.
     """
-    문서를 파싱하고 DataFrame으로 반환
-    - 항상 pandas.DataFrame 반환 보장
-    - 에러 발생 시 빈 DataFrame 반환
-    """
+
+    if not isinstance(text, str) or not text.strip():
+        return [], [], []
+
+    cases: List[ParsedSection] = []
+    rules: List[ParsedSection] = []
+    concepts: List[ParsedSection] = []
+
+    current_type: Optional[str] = None
+    current_title: str = ""
+    buffer: List[str] = []
+
+    def flush_buffer():
+        nonlocal buffer, current_type, current_title
+        if not buffer:
+            current_title = ""
+            return
+
+        content = "\n".join(buffer).strip()
+        buffer = []
+
+        if not content:
+            current_title = ""
+            return
+
+        title = current_title or {
+            "case": "사례",
+            "rule": "규칙",
+            "concept": "개념",
+        }.get(current_type or "concept", "내용")
+
+        if current_type == "case":
+            cases.append({"title": title, "detail": content})
+        elif current_type == "rule":
+            rules.append({"title": title, "desc": content})
+        else:
+            concepts.append({"title": title, "desc": content})
+
+        current_title = ""
+
+    keyword_map = {
+        "사례": "case",
+        "case": "case",
+        "규칙": "rule",
+        "rule": "rule",
+        "개념": "concept",
+        "concept": "concept",
+        "정의": "concept",
+    }
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+
+    for line in lines:
+        lowered = line.lower()
+        matched_type: Optional[str] = None
+        matched_keyword: Optional[str] = None
+
+        for keyword, section_type in keyword_map.items():
+            if lowered.startswith(keyword):
+                matched_type = section_type
+                matched_keyword = keyword
+                break
+
+        if matched_type:
+            flush_buffer()
+            current_type = matched_type
+
+            stripped_line = line.strip()
+
+            if ":" in stripped_line:
+                title, remainder = stripped_line.split(":", 1)
+                current_title = title.strip()
+                if remainder.strip():
+                    buffer.append(remainder.strip())
+            elif "-" in stripped_line and not stripped_line.startswith("-"):
+                title, remainder = stripped_line.split("-", 1)
+                current_title = title.strip()
+                if remainder.strip():
+                    buffer.append(remainder.strip())
+            else:
+                keyword_length = len(matched_keyword) if matched_keyword else 0
+                current_title = stripped_line[keyword_length:].strip() or matched_type
+            continue
+
+        if line.startswith(("-", "*", "•")):
+            item_text = line.lstrip("-*•").strip()
+            if not current_type:
+                current_type = "concept"
+            buffer.append(item_text)
+        else:
+            if not current_type:
+                current_type = "concept"
+            buffer.append(line)
+
+    flush_buffer()
+
+    return cases, rules, concepts
+
+
+def parse_and_store_documents(file_path: str) -> pd.DataFrame:
+    """문서를 파싱하고 파싱 결과를 DataFrame으로 저장한다."""
+
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
 
-        # 예시 파싱: 줄 단위로 저장
-        records = [
-            {"filename": os.path.basename(file_path), "line": i, "text": line.strip()}
-            for i, line in enumerate(content.splitlines(), start=1)
-            if line.strip()
-        ]
+        cases, rules, concepts = parse_document(content)
 
-        if not records:
-            return pd.DataFrame()
+        rows = []
+        filename = os.path.basename(file_path)
 
-        df = pd.DataFrame(records)
+        for idx, case in enumerate(cases, start=1):
+            detail = case.get("detail", "").strip()
+            if not detail:
+                continue
+            rows.append(
+                {
+                    "filename": filename,
+                    "category": "case",
+                    "title": case.get("title", f"사례 {idx}"),
+                    "content": detail,
+                }
+            )
 
-        # parsed_docs.csv에 누적 저장
+        for idx, rule in enumerate(rules, start=1):
+            desc = rule.get("desc", "").strip()
+            if not desc:
+                continue
+            rows.append(
+                {
+                    "filename": filename,
+                    "category": "rule",
+                    "title": rule.get("title", f"규칙 {idx}"),
+                    "content": desc,
+                }
+            )
+
+        for idx, concept in enumerate(concepts, start=1):
+            desc = concept.get("desc", "").strip()
+            if not desc:
+                continue
+            rows.append(
+                {
+                    "filename": filename,
+                    "category": "concept",
+                    "title": concept.get("title", f"개념 {idx}"),
+                    "content": desc,
+                }
+            )
+
+        df = pd.DataFrame(rows)
+
         parsed_csv = "data/parsed_docs.csv"
         os.makedirs("data", exist_ok=True)
+
         if not df.empty:
             if os.path.exists(parsed_csv):
                 old_df = pd.read_csv(parsed_csv)

--- a/streamlit_app_fixed/main.py
+++ b/streamlit_app_fixed/main.py
@@ -81,11 +81,17 @@ if st.button("CSV 전체 요약"):
     if not csv_dfs:
         st.warning("CSV 데이터가 없습니다.")
     else:
-        combined_text = "\n".join([df.to_string() for df in csv_dfs.values()])
-        summary = summarize_with_ai(combined_text)
-        st.text_area("요약 결과", summary, height=300)
+        try:
+            combined_df = pd.concat(list(csv_dfs.values()), ignore_index=True)
+        except ValueError as exc:
+            st.error(f"CSV 데이터를 결합하는 중 오류가 발생했습니다: {exc}")
+            combined_df = None
 
-        if st.button("요약 결과 저장"):
-            save_path = "data/summary.csv"
-            pd.DataFrame([{"summary": summary}]).to_csv(save_path, index=False, encoding="utf-8-sig")
-            st.success("요약 결과 저장 완료 ✅")
+        if combined_df is not None:
+            summary = summarize_with_ai(combined_df)
+            st.text_area("요약 결과", summary, height=300)
+
+            if st.button("요약 결과 저장"):
+                save_path = "data/summary.csv"
+                pd.DataFrame([{"summary": summary}]).to_csv(save_path, index=False, encoding="utf-8-sig")
+                st.success("요약 결과 저장 완료 ✅")


### PR DESCRIPTION
## Summary
- add a robust `parse_document` helper so the RAG pipeline can import it and classify document content into cases, rules, and concepts
- update `parse_and_store_documents` to reuse the shared parser, persist structured rows, and ignore empty sections safely

## Testing
- python -m compileall streamlit_app_fixed

------
https://chatgpt.com/codex/tasks/task_e_68cac5c2af4883309039e7b701124cb6