### PR TITLE
feat: enhance document parser and rule extraction

### DIFF
--- a/docu_app/backend/core/__init__.py
+++ b/docu_app/backend/core/__init__.py
@@ -1,0 +1,12 @@
+"""Core components for DocuQA backend."""
+
+from .parser import DocumentParser, DocumentParseResult, ParsedBlock
+from .extractor import RuleExtractor, RuleCandidate
+
+__all__ = [
+    "DocumentParser",
+    "DocumentParseResult",
+    "ParsedBlock",
+    "RuleExtractor",
+    "RuleCandidate",
+]

--- a/docu_app/backend/core/extractor.py
+++ b/docu_app/backend/core/extractor.py
@@ -1,0 +1,184 @@
+"""Advanced rule extraction utilities for DocuQA."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence
+import re
+
+from .parser import DocumentParseResult, ParsedBlock
+
+
+@dataclass
+class RuleCandidate:
+    """Represents a rule extracted from a document with provenance metadata."""
+
+    identifier: str
+    title: Optional[str]
+    content: str
+    confidence: float = 0.5
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "id": self.identifier,
+            "title": self.title,
+            "content": self.content,
+            "confidence": self.confidence,
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class RuleExtractor:
+    """Extracts rule candidates from parsed documents or raw text."""
+
+    #: captures numbered headings such as "1.", "가.", "제1조".
+    HEADING_PATTERN = re.compile(
+        r"^(?P<number>(?:제\s*\d+\s*조|제\s*\d+\s*항|[0-9]+\.|[A-Z]\.|[IVX]+\.|[가-힣]\.)\s*)(?P<title>.+)$",
+        re.MULTILINE,
+    )
+    #: fallback for bullet markers
+    BULLET_PATTERN = re.compile(r"^(?:[-*•]\s+)(?P<title>[^:：]+)[:：]\s*(?P<body>.+)$", re.MULTILINE)
+
+    def __init__(self, min_length: int = 50) -> None:
+        self.min_length = min_length
+
+    # ------------------------------------------------------------------
+    def extract(self, source: DocumentParseResult | str) -> List[RuleCandidate]:
+        """Extract rule candidates from a parse result or raw text."""
+        if isinstance(source, DocumentParseResult):
+            return self._extract_from_parse_result(source)
+        return self._extract_from_text(source)
+
+    # ------------------------------------------------------------------
+    def _extract_from_parse_result(self, result: DocumentParseResult) -> List[RuleCandidate]:
+        candidates: List[RuleCandidate] = []
+        for block in result.rules:
+            candidates.extend(self._expand_block(block, base_confidence=0.95))
+
+        # Recover additional rule-like structures from cases/concepts.
+        spillover_blocks = [*result.cases, *result.concepts]
+        for block in spillover_blocks:
+            inferred = self._expand_block(block, base_confidence=0.5, restrict_by_heading=True)
+            if inferred:
+                candidates.extend(inferred)
+        return self._deduplicate_candidates(candidates)
+
+    def _extract_from_text(self, text: str) -> List[RuleCandidate]:
+        pseudo_block = ParsedBlock(
+            identifier="raw-text",
+            title=None,
+            content=text,
+            metadata={"source_tag": "규칙"},
+        )
+        return self._deduplicate_candidates(self._expand_block(pseudo_block, base_confidence=0.4))
+
+    # ------------------------------------------------------------------
+    def _expand_block(
+        self,
+        block: ParsedBlock,
+        *,
+        base_confidence: float,
+        restrict_by_heading: bool = False,
+    ) -> List[RuleCandidate]:
+        content = block.content.strip()
+        if len(content) < self.min_length:
+            return []
+
+        matches = list(self.HEADING_PATTERN.finditer(content))
+        if matches:
+            return self._split_with_heading(block, matches, base_confidence)
+
+        bullet_matches = list(self.BULLET_PATTERN.finditer(content))
+        if bullet_matches and not restrict_by_heading:
+            return self._split_bullets(block, bullet_matches, base_confidence * 0.9)
+
+        if restrict_by_heading:
+            return []
+
+        return [
+            RuleCandidate(
+                identifier=self._ensure_identifier(block.identifier, block.title),
+                title=block.title,
+                content=content,
+                confidence=base_confidence,
+                metadata=dict(block.metadata),
+            )
+        ]
+
+    def _split_with_heading(
+        self,
+        block: ParsedBlock,
+        matches: Sequence[re.Match[str]],
+        base_confidence: float,
+    ) -> List[RuleCandidate]:
+        candidates: List[RuleCandidate] = []
+        for index, match in enumerate(matches):
+            start = match.start()
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(block.content)
+            snippet = block.content[start:end].strip()
+            if len(snippet) < self.min_length:
+                continue
+            number = match.group("number").strip()
+            title = match.group("title").strip()
+            identifier = self._ensure_identifier(title, block.identifier)
+            metadata = dict(block.metadata)
+            metadata.update({
+                "marker": number,
+                "source_tag": metadata.get("source_tag", "규칙"),
+            })
+            candidates.append(
+                RuleCandidate(
+                    identifier=identifier,
+                    title=title,
+                    content=snippet,
+                    confidence=min(1.0, base_confidence + 0.03),
+                    metadata=metadata,
+                )
+            )
+        return candidates
+
+    def _split_bullets(
+        self,
+        block: ParsedBlock,
+        matches: Sequence[re.Match[str]],
+        base_confidence: float,
+    ) -> List[RuleCandidate]:
+        candidates: List[RuleCandidate] = []
+        for match in matches:
+            title = match.group("title").strip()
+            body = match.group("body").strip()
+            snippet = f"{title}: {body}"
+            if len(snippet) < self.min_length:
+                continue
+            identifier = self._ensure_identifier(title, block.identifier)
+            metadata = dict(block.metadata)
+            metadata.setdefault("source_tag", "규칙")
+            metadata["marker"] = "bullet"
+            candidates.append(
+                RuleCandidate(
+                    identifier=identifier,
+                    title=title,
+                    content=snippet,
+                    confidence=base_confidence,
+                    metadata=metadata,
+                )
+            )
+        return candidates
+
+    # ------------------------------------------------------------------
+    def _ensure_identifier(self, preferred: Optional[str], fallback: Optional[str]) -> str:
+        base = (preferred or fallback or "rule").strip().lower()
+        base = re.sub(r"[^a-z0-9\-_.]+", "-", base)
+        base = re.sub(r"-+", "-", base).strip("-._") or "rule"
+        return base
+
+    def _deduplicate_candidates(self, candidates: Iterable[RuleCandidate]) -> List[RuleCandidate]:
+        unique: Dict[str, RuleCandidate] = {}
+        for candidate in candidates:
+            key = candidate.identifier
+            existing = unique.get(key)
+            if existing is None or candidate.confidence > existing.confidence:
+                unique[key] = candidate
+        return list(unique.values())

--- a/docu_app/backend/core/parser.py
+++ b/docu_app/backend/core/parser.py
@@ -1,0 +1,320 @@
+"""Utilities for parsing semi-structured legal documents used by DocuQA."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+import re
+import textwrap
+
+
+_TAG_PATTERN = re.compile(
+    r"<(?P<tag>사례|규칙|개념)(?P<attrs>[^>]*)>(?P<body>.*?)</(?P=tag)>",
+    re.DOTALL | re.IGNORECASE,
+)
+_ATTR_PATTERN = re.compile(r"([\w\-:]+)\s*=\s*\"([^\"]*)\"")
+_RULE_REFERENCE_PATTERN = re.compile(
+    r"(?:\(|\[)?(?:관련\s*)?규칙\s*[:：]\s*(?P<ids>[^)\]\n]+)(?:\)|\])?",
+    re.IGNORECASE,
+)
+_INLINE_RULE_PATTERN = re.compile(
+    r"규칙\s*(?P<id>[A-Za-z0-9_\-]+)",
+)
+_HEADING_PATTERN = re.compile(
+    r"^(?P<marker>(?:제\s*\d+\s*조|[0-9]+\.|[IVX]+\.|[A-Z]\.|[가-힣]\.)\s*)(?P<title>.+)$",
+    re.MULTILINE,
+)
+_SECTION_TITLE_PATTERN = re.compile(r"^(?:#|##|###)\s*(사례|규칙|개념)(.*)$", re.MULTILINE)
+
+
+@dataclass
+class ParsedBlock:
+    """Structured representation of a tagged block within the source document."""
+
+    identifier: str
+    title: Optional[str]
+    content: str
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Optional[str]]:
+        """Return a serialisable dictionary representation."""
+        data = {
+            "id": self.identifier,
+            "title": self.title,
+            "content": self.content,
+        }
+        data.update(self.metadata)
+        return data
+
+
+@dataclass
+class DocumentParseResult:
+    """Container for the parsed structure of a document."""
+
+    cases: List[ParsedBlock] = field(default_factory=list)
+    rules: List[ParsedBlock] = field(default_factory=list)
+    concepts: List[ParsedBlock] = field(default_factory=list)
+    references: Dict[str, List[str]] = field(default_factory=dict)
+    diagnostics: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Export the parse result as a dictionary."""
+        return {
+            "cases": [case.as_dict() for case in self.cases],
+            "rules": [rule.as_dict() for rule in self.rules],
+            "concepts": [concept.as_dict() for concept in self.concepts],
+            "references": self.references,
+            "diagnostics": list(self.diagnostics),
+        }
+
+
+class DocumentParser:
+    """Parses DocuQA domain specific documents into structured blocks.
+
+    The parser understands the `<사례>`, `<규칙>` and `<개념>` tags, but it also
+    includes a set of heuristics to recover structure from lightly formatted
+    text (e.g. Markdown headings). This makes the ingestion step much more
+    tolerant to human authored documents that do not strictly follow the
+    template.
+    """
+
+    def __init__(self, min_block_length: int = 20) -> None:
+        self.min_block_length = min_block_length
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def parse_document(self, text: str) -> DocumentParseResult:
+        """Parse a raw document string into structured entities.
+
+        Parameters
+        ----------
+        text:
+            The raw document body as a UTF-8 string.
+        """
+        normalised = self._normalise_text(text)
+        result = DocumentParseResult()
+
+        # First, extract explicitly tagged blocks.
+        tagged_blocks = list(self._extract_tagged_blocks(normalised))
+        consumed_spans: List[Tuple[int, int]] = []
+
+        for tag, attrs, body, span in tagged_blocks:
+            identifier = self._resolve_identifier(attrs, prefix=tag)
+            title = attrs.get("title") or self._derive_title(body)
+            cleaned = self._clean_block(body)
+            metadata = {k: v for k, v in attrs.items() if k not in {"id", "title"}}
+            metadata["source_tag"] = tag
+
+            block = ParsedBlock(identifier=identifier, title=title, content=cleaned, metadata=metadata)
+            if len(cleaned) < self.min_block_length:
+                result.diagnostics.append(
+                    f"Block '{identifier}' under <{tag}> ignored because content is too short."
+                )
+                continue
+
+            if tag.lower() == "사례":
+                result.cases.append(block)
+                references = self._extract_rule_references(cleaned)
+                if references:
+                    result.references[identifier] = references
+            elif tag.lower() == "규칙":
+                result.rules.append(block)
+            elif tag.lower() == "개념":
+                result.concepts.append(block)
+
+            consumed_spans.append(span)
+
+        # Secondly, capture any remaining sections via heuristics.
+        remainder = self._extract_remainder(normalised, consumed_spans)
+        if remainder.strip():
+            heuristic_blocks = self._extract_from_headings(remainder)
+            for block in heuristic_blocks:
+                if block.metadata["source_tag"] == "규칙":
+                    result.diagnostics.append(
+                        "Rule candidate recovered heuristically from Markdown heading: "
+                        f"{block.identifier}"
+                    )
+                    result.rules.append(block)
+                elif block.metadata["source_tag"] == "사례":
+                    result.cases.append(block)
+                else:
+                    result.concepts.append(block)
+
+        # Deduplicate rule references and normalise ids.
+        for case_id, refs in list(result.references.items()):
+            seen = set()
+            normalised_refs = []
+            for ref in refs:
+                clean_ref = self._normalise_identifier(ref, fallback_prefix="rule")
+                if clean_ref not in seen:
+                    seen.add(clean_ref)
+                    normalised_refs.append(clean_ref)
+            if normalised_refs:
+                result.references[case_id] = normalised_refs
+            else:
+                result.references.pop(case_id, None)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalise_text(self, text: str) -> str:
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        text = textwrap.dedent(text)
+        return text.strip()
+
+    def _extract_tagged_blocks(
+        self, text: str
+    ) -> Iterable[Tuple[str, Dict[str, str], str, Tuple[int, int]]]:
+        for match in _TAG_PATTERN.finditer(text):
+            tag = match.group("tag")
+            attrs = self._parse_attributes(match.group("attrs"))
+            body = match.group("body")
+            yield tag, attrs, body, match.span()
+
+    def _parse_attributes(self, attr_text: str) -> Dict[str, str]:
+        attributes: Dict[str, str] = {}
+        for key, value in _ATTR_PATTERN.findall(attr_text or ""):
+            attributes[key.lower()] = value.strip()
+        return attributes
+
+    def _resolve_identifier(self, attrs: Dict[str, str], prefix: str) -> str:
+        identifier = attrs.get("id") or attrs.get("name")
+        return self._normalise_identifier(identifier, fallback_prefix=prefix)
+
+    def _normalise_identifier(self, identifier: Optional[str], fallback_prefix: str) -> str:
+        if identifier:
+            candidate = identifier.strip().lower()
+        else:
+            candidate = ""
+        candidate = re.sub(r"[^a-z0-9\-_.]+", "-", candidate)
+        candidate = re.sub(r"-+", "-", candidate).strip("-._")
+        if not candidate:
+            candidate = f"{fallback_prefix}-{abs(hash(fallback_prefix)) % 10_000}"
+        return candidate
+
+    def _derive_title(self, body: str) -> Optional[str]:
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped:
+                return stripped.split("\u200b")[0][:120]
+        return None
+
+    def _clean_block(self, body: str) -> str:
+        cleaned = body.strip()
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+        return cleaned
+
+    def _extract_rule_references(self, text: str) -> List[str]:
+        references: List[str] = []
+        for match in _RULE_REFERENCE_PATTERN.finditer(text):
+            raw_ids = match.group("ids")
+            if not raw_ids:
+                continue
+            for ref in re.split(r"[,;\/\s]+", raw_ids):
+                ref = ref.strip()
+                if not ref:
+                    continue
+                references.append(ref)
+        for match in _INLINE_RULE_PATTERN.finditer(text):
+            references.append(match.group("id"))
+        return references
+
+    def _extract_remainder(self, text: str, spans: Sequence[Tuple[int, int]]) -> str:
+        if not spans:
+            return text
+        markers = sorted(spans)
+        remainder_parts: List[str] = []
+        cursor = 0
+        for start, end in markers:
+            remainder_parts.append(text[cursor:start])
+            cursor = end
+        remainder_parts.append(text[cursor:])
+        return "".join(remainder_parts)
+
+    def _extract_from_headings(self, text: str) -> List[ParsedBlock]:
+        blocks: List[ParsedBlock] = []
+        if not text:
+            return blocks
+
+        sections = []
+        last_pos = 0
+        for heading in _SECTION_TITLE_PATTERN.finditer(text):
+            start = heading.start()
+            if last_pos != start:
+                sections.append(text[last_pos:start])
+            sections.append(text[start:heading.end()])
+            last_pos = heading.end()
+        if last_pos < len(text):
+            sections.append(text[last_pos:])
+
+        current_tag = None
+        buffer: List[str] = []
+        for line in text.splitlines():
+            heading_match = _SECTION_TITLE_PATTERN.match(line)
+            if heading_match:
+                if buffer and current_tag:
+                    content = "\n".join(buffer).strip()
+                    if len(content) >= self.min_block_length:
+                        identifier = self._normalise_identifier(None, fallback_prefix=current_tag)
+                        blocks.append(
+                            ParsedBlock(
+                                identifier=identifier,
+                                title=None,
+                                content=content,
+                                metadata={"source_tag": current_tag},
+                            )
+                        )
+                current_tag = heading_match.group(1)
+                buffer = []
+            else:
+                buffer.append(line)
+        if buffer and current_tag:
+            content = "\n".join(buffer).strip()
+            if len(content) >= self.min_block_length:
+                identifier = self._normalise_identifier(None, fallback_prefix=current_tag)
+                blocks.append(
+                    ParsedBlock(
+                        identifier=identifier,
+                        title=None,
+                        content=content,
+                        metadata={"source_tag": current_tag},
+                    )
+                )
+
+        # Additionally attempt to split rules based on numbering.
+        enriched_blocks: List[ParsedBlock] = []
+        for block in blocks:
+            if block.metadata.get("source_tag") == "규칙":
+                sub_rules = list(self._split_numbered_rules(block))
+                if sub_rules:
+                    enriched_blocks.extend(sub_rules)
+                    continue
+            enriched_blocks.append(block)
+        return enriched_blocks
+
+    def _split_numbered_rules(self, block: ParsedBlock) -> Iterable[ParsedBlock]:
+        positions = list(_HEADING_PATTERN.finditer(block.content))
+        if not positions:
+            return []
+        segments: List[Tuple[int, int, re.Match[str]]] = []
+        for idx, match in enumerate(positions):
+            start = match.start()
+            end = positions[idx + 1].start() if idx + 1 < len(positions) else len(block.content)
+            segments.append((start, end, match))
+
+        for start, end, match in segments:
+            section = block.content[start:end].strip()
+            if len(section) < self.min_block_length:
+                continue
+            identifier = self._normalise_identifier(match.group("title"), fallback_prefix="rule")
+            metadata = dict(block.metadata)
+            metadata["marker"] = match.group("marker").strip()
+            metadata["source_tag"] = "규칙"
+            yield ParsedBlock(
+                identifier=identifier,
+                title=match.group("title").strip(),
+                content=section,
+                metadata=metadata,
+            )


### PR DESCRIPTION
## Summary
- add a resilient `DocumentParser` that understands tagged and Markdown-formatted sections while normalising references
- implement a richer `RuleExtractor` capable of splitting numbered and bulleted rules with confidence scoring
- expose the new parser and extractor utilities through the backend core package interface

## Testing
- python -m compileall docu_app/backend/core

------
https://chatgpt.com/codex/tasks/task_e_68cad1f6ea108330bcac172962ec478c