### PR TITLE
Fix dataframe import order for vector DB build

### DIFF
--- a/streamlit_app_fixed/core/rag.py
+++ b/streamlit_app_fixed/core/rag.py
@@ -34,11 +34,11 @@ def build_databases(data_dir="data/raw_docs", db_dir="data/vector_db"):
 
     # --- SQLite 저장 ---
     if all_cases:
-        import_df_to_db("cases", pd.DataFrame(all_cases))
+        import_df_to_db(pd.DataFrame(all_cases), "cases")
     if all_rules:
-        import_df_to_db("rules", pd.DataFrame(all_rules))
+        import_df_to_db(pd.DataFrame(all_rules), "rules")
     if all_concepts:
-        import_df_to_db("concepts", pd.DataFrame(all_concepts))
+        import_df_to_db(pd.DataFrame(all_concepts), "concepts")
 
     # --- VectorDB 빌드 ---
     texts = []


### PR DESCRIPTION
## Summary
- correct the argument order when importing parsed rule dataframes into SQLite during vector database builds
- ensure case, rule, and concept tables receive the expected pandas DataFrame input before persistence

## Testing
- python -m compileall streamlit_app_fixed

------
https://chatgpt.com/codex/tasks/task_e_68d12b8ec0d88330894e7ea05c787618