### PR TITLE
Expand saju analyzers with detailed rules

### DIFF
--- a/saju_program/__init__.py
+++ b/saju_program/__init__.py
@@ -1,0 +1,34 @@
+"""Saju program package exposing core analyzers and data."""
+
+from . import rules_data
+from .saju_core import (
+    EarthlyBranch,
+    Gungwi,
+    GungwiManager,
+    HeavenlyStem,
+    Pillar,
+    ShishinManager,
+    assign_gungwi,
+    create_earthly_branch,
+    create_heavenly_stem,
+    create_pillar,
+)
+from .saju_fortune import SajuFortuneAnalyzer
+from .saju_model import Saju, SajuAnalyzer
+
+__all__ = [
+    "EarthlyBranch",
+    "Gungwi",
+    "GungwiManager",
+    "HeavenlyStem",
+    "Pillar",
+    "ShishinManager",
+    "Saju",
+    "SajuAnalyzer",
+    "SajuFortuneAnalyzer",
+    "assign_gungwi",
+    "create_earthly_branch",
+    "create_heavenly_stem",
+    "create_pillar",
+    "rules_data",
+]

--- a/saju_program/rules_data.py
+++ b/saju_program/rules_data.py
@@ -1,0 +1,218 @@
+"""Static rule tables used throughout the 사주 도구."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+# --- 기본 데이터 ---------------------------------------------------------
+
+HEAVENLY_STEMS: Dict[str, Dict[str, str]] = {
+    "甲": {"ohaeng": "목", "yinyang": "양"},
+    "乙": {"ohaeng": "목", "yinyang": "음"},
+    "丙": {"ohaeng": "화", "yinyang": "양"},
+    "丁": {"ohaeng": "화", "yinyang": "음"},
+    "戊": {"ohaeng": "토", "yinyang": "양"},
+    "己": {"ohaeng": "토", "yinyang": "음"},
+    "庚": {"ohaeng": "금", "yinyang": "양"},
+    "辛": {"ohaeng": "금", "yinyang": "음"},
+    "壬": {"ohaeng": "수", "yinyang": "양"},
+    "癸": {"ohaeng": "수", "yinyang": "음"},
+}
+
+EARTHLY_BRANCHES: Dict[str, Dict[str, object]] = {
+    "子": {
+        "ohaeng": "수",
+        "yinyang": "양",
+        "gijeong": {"임": {"ohaeng": "수", "yinyang": "양"}},
+    },
+    "丑": {
+        "ohaeng": "토",
+        "yinyang": "음",
+        "gijeong": {
+            "계": {"ohaeng": "수", "yinyang": "음"},
+            "신": {"ohaeng": "금", "yinyang": "음"},
+            "기": {"ohaeng": "토", "yinyang": "음"},
+        },
+    },
+    "寅": {
+        "ohaeng": "목",
+        "yinyang": "양",
+        "gijeong": {
+            "무": {"ohaeng": "토", "yinyang": "양"},
+            "병": {"ohaeng": "화", "yinyang": "양"},
+            "갑": {"ohaeng": "목", "yinyang": "양"},
+        },
+    },
+    "卯": {
+        "ohaeng": "목",
+        "yinyang": "음",
+        "gijeong": {
+            "갑": {"ohaeng": "목", "yinyang": "양"},
+            "을": {"ohaeng": "목", "yinyang": "음"},
+        },
+    },
+    "辰": {
+        "ohaeng": "토",
+        "yinyang": "양",
+        "gijeong": {
+            "을": {"ohaeng": "목", "yinyang": "음"},
+            "계": {"ohaeng": "수", "yinyang": "음"},
+            "무": {"ohaeng": "토", "yinyang": "양"},
+        },
+    },
+    "巳": {
+        "ohaeng": "화",
+        "yinyang": "음",
+        "gijeong": {
+            "무": {"ohaeng": "토", "yinyang": "양"},
+            "경": {"ohaeng": "금", "yinyang": "양"},
+            "병": {"ohaeng": "화", "yinyang": "양"},
+        },
+    },
+    "午": {
+        "ohaeng": "화",
+        "yinyang": "양",
+        "gijeong": {
+            "기": {"ohaeng": "토", "yinyang": "음"},
+            "병": {"ohaeng": "화", "yinyang": "양"},
+        },
+    },
+    "未": {
+        "ohaeng": "토",
+        "yinyang": "음",
+        "gijeong": {
+            "정": {"ohaeng": "화", "yinyang": "음"},
+            "을": {"ohaeng": "목", "yinyang": "음"},
+            "기": {"ohaeng": "토", "yinyang": "음"},
+        },
+    },
+    "申": {
+        "ohaeng": "금",
+        "yinyang": "양",
+        "gijeong": {
+            "무": {"ohaeng": "토", "yinyang": "양"},
+            "임": {"ohaeng": "수", "yinyang": "양"},
+            "경": {"ohaeng": "금", "yinyang": "양"},
+        },
+    },
+    "酉": {
+        "ohaeng": "금",
+        "yinyang": "음",
+        "gijeong": {
+            "경": {"ohaeng": "금", "yinyang": "양"},
+            "신": {"ohaeng": "금", "yinyang": "음"},
+        },
+    },
+    "戌": {
+        "ohaeng": "토",
+        "yinyang": "양",
+        "gijeong": {
+            "신": {"ohaeng": "금", "yinyang": "음"},
+            "정": {"ohaeng": "화", "yinyang": "음"},
+            "무": {"ohaeng": "토", "yinyang": "양"},
+        },
+    },
+    "亥": {
+        "ohaeng": "수",
+        "yinyang": "음",
+        "gijeong": {
+            "무": {"ohaeng": "토", "yinyang": "양"},
+            "갑": {"ohaeng": "목", "yinyang": "양"},
+            "임": {"ohaeng": "수", "yinyang": "양"},
+        },
+    },
+}
+
+WUXING = {**{k: v["ohaeng"] for k, v in HEAVENLY_STEMS.items()}, **{k: v["ohaeng"] for k, v in EARTHLY_BRANCHES.items()}}
+
+OHAENG_ORDER: Sequence[str] = ("목", "화", "토", "금", "수")
+
+
+# --- 지지 상호작용 세트 -------------------------------------------------
+
+CHONG = {("子", "午"), ("丑", "未"), ("寅", "申"), ("卯", "酉"), ("辰", "戌"), ("巳", "亥")}
+XING = {
+    ("子", "卯"),
+    ("丑", "戌"),
+    ("寅", "巳"),
+    ("卯", "子"),
+    ("辰", "辰"),
+    ("巳", "申"),
+    ("午", "午"),
+    ("未", "丑"),
+    ("申", "巳"),
+    ("酉", "酉"),
+    ("戌", "丑"),
+    ("亥", "亥"),
+}
+PO = {("子", "酉"), ("卯", "午"), ("寅", "亥"), ("辰", "丑"), ("巳", "申"), ("未", "戌")}
+CHUAN = {("子", "未"), ("丑", "午"), ("寅", "巳"), ("卯", "辰"), ("申", "亥"), ("酉", "戌")}
+HAP = {("子", "丑"), ("寅", "亥"), ("卯", "戌"), ("辰", "酉"), ("巳", "申"), ("午", "未")}
+SAMHAP = {
+    ("寅", "午", "戌"): "화",
+    ("巳", "酉", "丑"): "금",
+    ("申", "子", "辰"): "수",
+    ("亥", "卯", "未"): "목",
+}
+
+
+# --- 십신 판단을 위한 보조 데이터 ---------------------------------------
+
+OHAENG_RELATIONS = {
+    "목": {"생": "화", "극": "토", "피생": "수", "피극": "금"},
+    "화": {"생": "토", "극": "금", "피생": "목", "피극": "수"},
+    "토": {"생": "금", "극": "수", "피생": "화", "피극": "목"},
+    "금": {"생": "수", "극": "목", "피생": "토", "피극": "화"},
+    "수": {"생": "목", "극": "화", "피생": "금", "피극": "토"},
+}
+
+SIPSIN_MAP = {
+    ("비슷", "음양같음"): "비견",
+    ("비슷", "음양다름"): "겁재",
+    ("생", "음양같음"): "식신",
+    ("생", "음양다름"): "상관",
+    ("피생", "음양같음"): "편인",
+    ("피생", "음양다름"): "정인",
+    ("극", "음양같음"): "편재",
+    ("극", "음양다름"): "정재",
+    ("피극", "음양같음"): "편관",
+    ("피극", "음양다름"): "정관",
+}
+
+SHISHIN_DEFAULT_DATA = {
+    "비견": {"description": "자아·주체성"},
+    "겁재": {"description": "경쟁·독립심"},
+    "식신": {"description": "재능·표현력"},
+    "상관": {"description": "언변·임기응변"},
+    "정재": {"description": "안정적 재물"},
+    "편재": {"description": "유동 자금·사업"},
+    "정관": {"description": "명예·규범"},
+    "편관": {"description": "권력·통제"},
+    "정인": {"description": "학문·문서"},
+    "편인": {"description": "기획력·직관"},
+}
+
+
+# --- 유틸리티 -----------------------------------------------------------
+
+def pair_contains(pair_set: Iterable[Tuple[str, str]], a: str, b: str) -> bool:
+    """Return True if the unordered pair exists in ``pair_set``."""
+
+    return (a, b) in pair_set or (b, a) in pair_set
+
+
+def build_wuxing_lookup(values: Sequence[str]) -> Dict[str, List[str]]:
+    """Group 천간/지지를 오행 기준으로 묶는다."""
+
+    grouped: Dict[str, List[str]] = defaultdict(list)
+    for symbol, ohaeng in values:
+        grouped[ohaeng].append(symbol)
+    return grouped
+
+
+def has_root(stem_name: str, branches: Sequence[str]) -> bool:
+    """Return True if ``stem_name`` finds 같은 오행 among ``branches``."""
+
+    stem_ohaeng = WUXING.get(stem_name, "")
+    return any(WUXING.get(branch, "") == stem_ohaeng for branch in branches)

--- a/saju_program/run_example.py
+++ b/saju_program/run_example.py
@@ -1,0 +1,49 @@
+"""Example script demonstrating the advanced 사주 분석 파이프라인."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+if __package__ is None:  # pragma: no cover - script execution support
+    PACKAGE_ROOT = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, os.path.dirname(PACKAGE_ROOT))
+
+from saju_program import (
+    GungwiManager,
+    Saju,
+    SajuAnalyzer,
+    SajuFortuneAnalyzer,
+    create_pillar,
+)
+
+
+def main() -> None:
+    gungwi_manager = GungwiManager()
+
+    # 예시 사주 (丁丙辛戊 / 酉申酉未)
+    year_pillar = create_pillar("丙", "申")
+    month_pillar = create_pillar("丙", "申")
+    day_pillar = create_pillar("辛", "酉")
+    time_pillar = create_pillar("丁", "未")
+
+    saju = Saju(year_pillar, month_pillar, day_pillar, time_pillar, gungwi_manager)
+    print(saju)
+
+    analyzer = SajuAnalyzer(saju)
+    analyzer.analyze_gungwi()
+    analyzer.analyze_sipsin()
+    analyzer.analyze_branch_relations()
+    analyzer.analyze_cheyong_and_jubin(ilgan_is_strong=False)
+    analyzer.analyze_advanced_rules()
+    analyzer.analyze_gongmang(["戌", "亥"])
+
+    # 대운/세운 예시
+    daewoon = create_pillar("己", "酉")
+    sewoon = create_pillar("丁", "卯")
+    fortune = SajuFortuneAnalyzer(saju, daewoon, sewoon)
+    fortune.analyze_interactions()
+
+
+if __name__ == "__main__":
+    main()

--- a/saju_program/saju_core.py
+++ b/saju_program/saju_core.py
@@ -1,0 +1,174 @@
+"""Core domain models and factories for Saju analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+
+@dataclass(slots=True)
+class HeavenlyStem:
+    """Represents one of the ten heavenly stems (천간)."""
+
+    name: str
+    ohaeng: str
+    yinyang: str
+    sipsin: Optional[str] = None  # 십신은 동적으로 할당
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"{self.name}"
+
+
+@dataclass(slots=True)
+class EarthlyBranch:
+    """Represents one of the twelve earthly branches (지지)."""
+
+    name: str
+    ohaeng: str
+    yinyang: str
+    gijeong: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"{self.name}"
+
+
+@dataclass(slots=True)
+class Gungwi:
+    """Represents the palace/house (궁위) associated with each pillar."""
+
+    name: str
+    life_stage: str
+    representative_kin: str
+    symbolic_meaning: str
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"{self.name}({self.representative_kin})"
+
+
+@dataclass(slots=True)
+class Shishin:
+    """Describes one of the ten gods (십신) with optional relationship metadata."""
+
+    name: str
+    description: str
+    relations: Dict[str, str] = field(default_factory=dict)
+
+    def get_relationship(self, other_shishin_name: str) -> str:
+        return self.relations.get(other_shishin_name, "관계 없음")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"Shishin(name='{self.name}')"
+
+
+@dataclass(slots=True)
+class Pillar:
+    """Represents one pillar consisting of a stem, branch, and optional 궁위."""
+
+    stem: HeavenlyStem
+    branch: EarthlyBranch
+    gungwi: Optional[Gungwi] = None
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        if self.gungwi:
+            return f"{self.stem}{self.branch}({self.gungwi.name})"
+        return f"{self.stem}{self.branch}"
+
+
+class GungwiManager:
+    """Provides lookup access for 궁위 definitions."""
+
+    def __init__(self, data: Optional[Dict[str, Dict[str, str]]] = None) -> None:
+        if data is None:
+            data = {
+                "년주": {
+                    "life_stage": "유년 시기 (1-18세)",
+                    "representative_kin": "조상·부모·노인·선배",
+                    "symbolic_meaning": "해외·원방·변방지역",
+                },
+                "월주": {
+                    "life_stage": "청년 시기 (18-35세)",
+                    "representative_kin": "부모·형제·동료·상사",
+                    "symbolic_meaning": "본적·고향·일터",
+                },
+                "일주": {
+                    "life_stage": "장년 시기 (35-55세)",
+                    "representative_kin": "배우자·가까운 지인",
+                    "symbolic_meaning": "자아·사유재산",
+                },
+                "시주": {
+                    "life_stage": "말년 (55세 이후)",
+                    "representative_kin": "자녀·후배·제자",
+                    "symbolic_meaning": "문호·출구·미래",
+                },
+            }
+
+        self._gungwis = {
+            name: Gungwi(
+                name=name,
+                life_stage=info["life_stage"],
+                representative_kin=info["representative_kin"],
+                symbolic_meaning=info["symbolic_meaning"],
+            )
+            for name, info in data.items()
+        }
+
+    def get_gungwi(self, name: str) -> Optional[Gungwi]:
+        return self._gungwis.get(name)
+
+
+class ShishinManager:
+    """Stores 십신 metadata referenced during 분석."""
+
+    def __init__(self, data: Dict[str, Dict[str, str]]) -> None:
+        self._shishins = {
+            name: Shishin(
+                name=name,
+                description=info.get("description", ""),
+                relations=info.get("relations", {}),
+            )
+            for name, info in data.items()
+        }
+
+    def get_shishin(self, name: str) -> Optional[Shishin]:
+        return self._shishins.get(name)
+
+
+def create_heavenly_stem(name: str) -> HeavenlyStem:
+    """Factory that builds a :class:`HeavenlyStem` from rules data."""
+
+    from . import rules_data
+
+    data = rules_data.HEAVENLY_STEMS.get(name)
+    if data is None:
+        raise KeyError(f"알 수 없는 천간: {name}")
+    return HeavenlyStem(name=name, ohaeng=data["ohaeng"], yinyang=data["yinyang"])
+
+
+def create_earthly_branch(name: str) -> EarthlyBranch:
+    """Factory that builds an :class:`EarthlyBranch` from rules data."""
+
+    from . import rules_data
+
+    data = rules_data.EARTHLY_BRANCHES.get(name)
+    if data is None:
+        raise KeyError(f"알 수 없는 지지: {name}")
+    return EarthlyBranch(
+        name=name,
+        ohaeng=data["ohaeng"],
+        yinyang=data["yinyang"],
+        gijeong=data.get("gijeong", {}),
+    )
+
+
+def create_pillar(stem_name: str, branch_name: str, gungwi: Optional[Gungwi] = None) -> Pillar:
+    """Convenience helper to construct a pillar from symbolic names."""
+
+    return Pillar(create_heavenly_stem(stem_name), create_earthly_branch(branch_name), gungwi)
+
+
+def assign_gungwi(pillars: Iterable[Pillar], gungwi_manager: GungwiManager) -> None:
+    """Assign 궁위 information to the standard 년/월/일/시 pillar ordering."""
+
+    order = ["년주", "월주", "일주", "시주"]
+    for pillar, gungwi_name in zip(pillars, order):
+        pillar.gungwi = gungwi_manager.get_gungwi(gungwi_name)

--- a/saju_program/saju_fortune.py
+++ b/saju_program/saju_fortune.py
@@ -1,0 +1,91 @@
+"""Fortune analysis (대운/세운) interactions and detection logic."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import List, Tuple
+
+from . import rules_data
+from .saju_core import Pillar
+from .saju_model import Saju
+
+
+class SajuFortuneAnalyzer:
+    """대운·세운과 원국 간의 합·충·형·파·입묘를 감지합니다."""
+
+    def __init__(self, saju: Saju, daewoon: Pillar, sewoon: Pillar) -> None:
+        self.saju = saju
+        self.daewoon = daewoon
+        self.sewoon = sewoon
+
+    def _collect_branch_sources(self) -> List[Tuple[str, str]]:
+        return [
+            ("원국-년", self.saju.year.branch.name),
+            ("원국-월", self.saju.month.branch.name),
+            ("원국-일", self.saju.day.branch.name),
+            ("원국-시", self.saju.time.branch.name),
+            ("대운", self.daewoon.branch.name),
+            ("세운", self.sewoon.branch.name),
+        ]
+
+    def analyze_interactions(self) -> None:
+        print("--- 대운/세운 합·충·형·파·입묘 분석 ---")
+        print(f"대운: {self.daewoon}")
+        print(f"세운: {self.sewoon}")
+
+        branch_sources = self._collect_branch_sources()
+        self._report_pairwise_relations(branch_sources)
+        self._report_samhap(branch_sources)
+        self._report_myogo(branch_sources)
+        print("-" * 20)
+
+    # ------------------------------------------------------------------
+    def _report_pairwise_relations(self, branch_sources: List[Tuple[str, str]]) -> None:
+        seen = False
+        for (label_a, branch_a), (label_b, branch_b) in combinations(branch_sources, 2):
+            relation = None
+            message = ""
+            if rules_data.pair_contains(rules_data.CHONG, branch_a, branch_b):
+                relation = "충(沖)"
+                message = "→ 충돌·변화·분리"
+            elif rules_data.pair_contains(rules_data.XING, branch_a, branch_b):
+                relation = "형(刑)"
+                message = "→ 갈등·법적 이슈"
+            elif rules_data.pair_contains(rules_data.PO, branch_a, branch_b):
+                relation = "파(破)"
+                message = "→ 균열·와해"
+            elif rules_data.pair_contains(rules_data.CHUAN, branch_a, branch_b):
+                relation = "천(穿)"
+                message = "→ 강력한 제압"
+            elif rules_data.pair_contains(rules_data.HAP, branch_a, branch_b):
+                relation = "합(合)"
+                message = "→ 결합·협력"
+
+            if relation:
+                print(f"  - {label_a}({branch_a}) ↔ {label_b}({branch_b}): {relation} {message}")
+                seen = True
+
+        if not seen:
+            print("  - 운과 원국 사이에 특이 관계가 발견되지 않았습니다.")
+
+    def _report_samhap(self, branch_sources: List[Tuple[str, str]]) -> None:
+        available = {branch for _, branch in branch_sources}
+        for combo, element in rules_data.SAMHAP.items():
+            if all(branch in available for branch in combo):
+                labels = [label for label, branch in branch_sources if branch in combo]
+                joined_labels = "/".join(labels)
+                joined_branches = "/".join(combo)
+                print(f"  - {joined_branches} 삼합 성립 ({joined_labels}) → {element} 기운 극대화")
+
+    def _report_myogo(self, branch_sources: List[Tuple[str, str]]) -> None:
+        myogo_branches = {"辰", "戌", "丑", "未"}
+        branch_map = {branch: label for label, branch in branch_sources}
+        for branch in myogo_branches & set(branch_map.keys()):
+            interacts = any(
+                rules_data.pair_contains(rules_data.CHONG, branch, other)
+                or rules_data.pair_contains(rules_data.XING, branch, other)
+                for other in branch_map
+                if other != branch
+            )
+            state = "입묘 → 庫(고)로 활용" if interacts else "입묘 → 墓(묘)로 정체"
+            print(f"  - {branch_map[branch]}({branch}): {state}")

--- a/saju_program/saju_model.py
+++ b/saju_program/saju_model.py
@@ -1,0 +1,217 @@
+"""Models and analyzers for the natal chart (원국) including 궁위 logic."""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Iterable, List, Optional, Sequence
+
+from . import rules_data
+from .saju_core import (
+    GungwiManager,
+    Pillar,
+    ShishinManager,
+    assign_gungwi,
+)
+
+
+class Saju:
+    """Represents a natal chart consisting of four pillars."""
+
+    def __init__(
+        self,
+        year: Pillar,
+        month: Pillar,
+        day: Pillar,
+        time: Pillar,
+        gungwi_manager: Optional[GungwiManager] = None,
+    ) -> None:
+        self.year = year
+        self.month = month
+        self.day = day
+        self.time = time
+
+        if gungwi_manager is None:
+            gungwi_manager = GungwiManager()
+        assign_gungwi(self.get_pillars(), gungwi_manager)
+
+    def get_pillars(self) -> List[Pillar]:
+        return [self.year, self.month, self.day, self.time]
+
+    def get_stems(self) -> List[str]:
+        return [pillar.stem.name for pillar in self.get_pillars()]
+
+    def get_branches(self) -> List[str]:
+        return [pillar.branch.name for pillar in self.get_pillars()]
+
+    def __iter__(self) -> Iterable[Pillar]:
+        return iter(self.get_pillars())
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"사주: {self.year}, {self.month}, {self.day}, {self.time}"
+
+
+class SajuAnalyzer:
+    """고급 사주 분석 (궁위·십신·형충파해·묘고 등)을 수행합니다."""
+
+    def __init__(self, saju: Saju, shishin_manager: Optional[ShishinManager] = None) -> None:
+        self.saju = saju
+        if shishin_manager is None:
+            shishin_manager = ShishinManager(rules_data.SHISHIN_DEFAULT_DATA)
+        self.shishin_manager = shishin_manager
+
+    # --- 십신 계산 -----------------------------------------------------
+    def calculate_sipsin(self, ilgan, target) -> str:
+        if ilgan.name == target.name:
+            return "일간"
+
+        ilgan_ohaeng = ilgan.ohaeng
+        target_ohaeng = target.ohaeng
+        ohaeng_relation = "비슷"
+
+        relation_map = rules_data.OHAENG_RELATIONS[ilgan_ohaeng]
+        if relation_map["생"] == target_ohaeng:
+            ohaeng_relation = "생"
+        elif relation_map["극"] == target_ohaeng:
+            ohaeng_relation = "극"
+        elif relation_map["피생"] == target_ohaeng:
+            ohaeng_relation = "피생"
+        elif relation_map["피극"] == target_ohaeng:
+            ohaeng_relation = "피극"
+
+        yinyang_relation = "음양같음" if ilgan.yinyang == target.yinyang else "음양다름"
+        return rules_data.SIPSIN_MAP.get((ohaeng_relation, yinyang_relation), "십신 계산 오류")
+
+    def analyze_sipsin(self) -> None:
+        print("--- 십신 분석 ---")
+        ilgan = self.saju.day.stem
+        branch_names = self.saju.get_branches()
+
+        for pillar in self.saju:
+            print(f"**{pillar}**")
+            stem_sipsin_name = self.calculate_sipsin(ilgan, pillar.stem)
+            if stem_sipsin_name == "일간":
+                print(f"  > 천간: {pillar.stem.name} (일간)")
+            else:
+                print(f"  > 천간: {pillar.stem.name}는 {stem_sipsin_name}입니다.")
+                has_root = rules_data.has_root(pillar.stem.name, branch_names)
+                description = self.shishin_manager.get_shishin(stem_sipsin_name)
+                if has_root:
+                    print("    - 지지의 뿌리를 얻어 실(實)합니다.")
+                else:
+                    extra = f" ({description.description})" if description else ""
+                    print(f"    - 지지에 뿌리가 없어 허투(虛透)합니다.{extra}")
+
+            print("  > 지장간 십신:")
+            for gan_name, gan_info in pillar.branch.gijeong.items():
+                temp_stem = type(pillar.stem)(gan_name, gan_info["ohaeng"], gan_info["yinyang"])
+                gijeong_sipsin_name = self.calculate_sipsin(ilgan, temp_stem)
+                print(f"    - {gan_name}는 {gijeong_sipsin_name}입니다.")
+            print("-" * 20)
+
+    # --- 궁위 -----------------------------------------------------------
+    def analyze_gungwi(self) -> None:
+        print("--- 궁위 분석 ---")
+        for pillar in self.saju:
+            if pillar.gungwi:
+                print(f"**{pillar}**")
+                print(f"  - 궁위: {pillar.gungwi.name}")
+                print(f"  - 해당 시기: {pillar.gungwi.life_stage}")
+                print(f"  - 대표 육친: {pillar.gungwi.representative_kin}")
+                print(f"  - 상징 의미: {pillar.gungwi.symbolic_meaning}")
+        print("-" * 20)
+
+    # --- 지지 상호작용 -------------------------------------------------
+    def analyze_branch_relations(self) -> None:
+        print("--- 지지 관계 분석 (합·충·형·파·천) ---")
+        branches = self.saju.get_branches()
+        relations_found = False
+
+        for left, right in combinations(branches, 2):
+            if rules_data.pair_contains(rules_data.CHONG, left, right):
+                print(f"  - {left}/{right}: 충(沖) → 충돌·변화·분리")
+                relations_found = True
+            elif rules_data.pair_contains(rules_data.XING, left, right):
+                print(f"  - {left}/{right}: 형(刑) → 갈등·법적 문제")
+                relations_found = True
+            elif rules_data.pair_contains(rules_data.CHUAN, left, right):
+                print(f"  - {left}/{right}: 천(穿) → 강한 제압·살상력")
+                relations_found = True
+            elif rules_data.pair_contains(rules_data.PO, left, right):
+                print(f"  - {left}/{right}: 파(破) → 균열·와해")
+                relations_found = True
+            elif rules_data.pair_contains(rules_data.HAP, left, right):
+                print(f"  - {left}/{right}: 합(合) → 결합·협력")
+                relations_found = True
+
+        # 삼합 체크
+        for combo, element in rules_data.SAMHAP.items():
+            if all(branch in branches for branch in combo):
+                joined = "/".join(combo)
+                print(f"  - {joined}: 삼합으로 {element} 기운이 강화됩니다.")
+                relations_found = True
+
+        if not relations_found:
+            print("  - 사주에 특이한 지지 관계가 없습니다.")
+        print("-" * 20)
+
+    # --- 체용 및 주빈 ---------------------------------------------------
+    def analyze_cheyong_and_jubin(self, ilgan_is_strong: bool = False) -> None:
+        print("--- 체용(體用) 및 주빈(主賓) 분석 ---")
+        ilgan_name = self.saju.day.stem.name
+        print(f"일간 {ilgan_name} 기준으로 체/용을 판별합니다.")
+
+        for pillar in self.saju:
+            stem_sipsin = self.calculate_sipsin(self.saju.day.stem, pillar.stem)
+            if stem_sipsin in {"식신", "상관"}:
+                cheyong_type = "용" if ilgan_is_strong else "체"
+            elif stem_sipsin in {"비견", "겁재", "정인", "편인"}:
+                cheyong_type = "체"
+            else:
+                cheyong_type = "용"
+            print(f"  - {pillar.stem.name}: {cheyong_type} ({stem_sipsin})")
+
+        print("주위(主位): 일간·일주·시주")
+        print("빈위(賓位): 년주·월주 및 외부 운")
+        print("-" * 20)
+
+    # --- 허실·묘고 ------------------------------------------------------
+    def analyze_advanced_rules(self) -> None:
+        print("--- 간지 허실 및 묘고 분석 ---")
+        branch_list = self.saju.get_branches()
+
+        print("[간지 허실]")
+        for pillar in self.saju:
+            stem_name = pillar.stem.name
+            branch_name = pillar.branch.name
+            same_element = rules_data.WUXING.get(stem_name) == rules_data.WUXING.get(branch_name)
+            rooted_elsewhere = rules_data.has_root(stem_name, branch_list)
+            is_heo = not (same_element or rooted_elsewhere)
+            status = "실(實)" if not is_heo else "허(虛)"
+            print(f"  - {stem_name}{branch_name}주: {status}한 기세")
+
+        print("[묘고 상태]")
+        myogo_branches = {"辰", "戌", "丑", "未"}
+        for branch in branch_list:
+            if branch in myogo_branches:
+                has_interaction = any(
+                    branch != other
+                    and (
+                        rules_data.pair_contains(rules_data.CHONG, branch, other)
+                        or rules_data.pair_contains(rules_data.XING, branch, other)
+                    )
+                    for other in branch_list
+                )
+                status = "庫(고) → 활용 가능" if has_interaction else "墓(묘) → 잠재·정체"
+                print(f"  - {branch}: {status}")
+        print("-" * 20)
+
+    # --- 공망 ------------------------------------------------------------
+    def analyze_gongmang(self, gongmang_list: Sequence[str]) -> None:
+        print("--- 공망(空亡) 체크 ---")
+        matched = [symbol for symbol in gongmang_list if symbol in self.saju.get_stems() or symbol in self.saju.get_branches()]
+        if matched:
+            joined = ", ".join(matched)
+            print(f"사주에 공망 기운 {joined} 이/가 포함됩니다 → 허무·손실·유명무실 경향")
+        else:
+            print("공망 기운이 포함되지 않았습니다.")
+        print("-" * 20)


### PR DESCRIPTION
## Summary
- enrich the saju core with 십신/궁위 managers, factory helpers, and comprehensive 간지 데이터
- extend the natal analyzer to compute 십신, 체용, 지지 관계, 공망, and 묘고/허실 진단
- upgrade the fortune analyzer to detect 합·충·형·파·입묘 interactions across 대운·세운 and 원국, and refresh the example script to showcase the new workflow

## Testing
- `python saju_program/run_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5697a37148330a692cba599174018