### PR TITLE
Implement comprehensive saju analysis pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,9 @@ env.bak/
 venv.bak/
 
 # Application data directories
+uploads/
 data/
+saju_reports.db
 !suam_ai/data/
 !suam_ai/data/rules.json
 exports/

--- a/Main.py
+++ b/Main.py
@@ -1,0 +1,134 @@
+"""Main pipeline orchestrating 문서 업로드 → 파싱 → 사주 객체화 → DB 저장."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from textwrap import dedent
+
+from saju_program import rules_data
+from saju_program.saju_core import EarthlyBranch, GungwiManager, HeavenlyStem, Pillar, ShishinManager
+from saju_program.saju_fortune import SajuFortuneAnalyzer
+from saju_program.saju_model import Saju, SajuAnalyzer, parse_saju_documents
+
+UPLOAD_DIR = Path("uploads")
+DB_PATH = Path("saju_reports.db")
+
+
+def simulate_upload() -> Path:
+    """샘플 문서를 업로드 디렉터리에 저장한다."""
+
+    UPLOAD_DIR.mkdir(exist_ok=True)
+    sample_file = UPLOAD_DIR / "guide.md"
+    sample_file.write_text(
+        dedent(
+            """
+            # 업로드된 사주 문서
+
+            체: 비견, 겁재, 정인
+            용: 정재, 편재, 정관
+            중립: 식신, 상관
+
+            공망 갑자: 갑자, 을축
+            공망 병인: 경신, 신유
+
+            묘고의 원칙
+            • 묘고는 형/충을 기뻐하며, 형/충이 없으면 묘가 된다.
+
+            허실 판단
+            • 지지가 뿌리가 되지 못하면 허투로 본다.
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return UPLOAD_DIR
+
+
+def build_saju(parsed_data: dict[str, object]):
+    """샘플 원국/대운/세운을 생성하고 분석 결과를 반환한다."""
+
+    gungwi_manager = GungwiManager()
+    shishin_manager = ShishinManager(rules_data.DEFAULT_SHISHIN_DATA)
+
+    year_pillar = Pillar(HeavenlyStem.from_name("丙"), EarthlyBranch.from_name("申"))
+    month_pillar = Pillar(HeavenlyStem.from_name("丙"), EarthlyBranch.from_name("申"))
+    day_pillar = Pillar(HeavenlyStem.from_name("辛"), EarthlyBranch.from_name("酉"))
+    time_pillar = Pillar(HeavenlyStem.from_name("丁"), EarthlyBranch.from_name("未"))
+
+    saju = Saju(year_pillar, month_pillar, day_pillar, time_pillar, gungwi_manager)
+    analyzer = SajuAnalyzer(saju, shishin_manager, parsed_data)
+    natal_report = analyzer.generate_report()
+
+    daewoon = Pillar(HeavenlyStem.from_name("己"), EarthlyBranch.from_name("丑"))
+    sewoon = Pillar(HeavenlyStem.from_name("丁"), EarthlyBranch.from_name("卯"))
+    fortune_analyzer = SajuFortuneAnalyzer(saju, daewoon, sewoon)
+    fortune_report = fortune_analyzer.generate_report()
+
+    metadata = {
+        "natal": [f"{p.stem.name}{p.branch.name}" for p in saju.get_pillars()],
+        "daewoon": f"{daewoon.stem.name}{daewoon.branch.name}",
+        "sewoon": f"{sewoon.stem.name}{sewoon.branch.name}",
+    }
+
+    return natal_report, fortune_report, metadata
+
+
+def store_reports(natal_report: str, fortune_report: str, metadata: dict[str, object]) -> None:
+    """분석 결과를 SQLite 데이터베이스에 저장한다."""
+
+    connection = sqlite3.connect(DB_PATH)
+    try:
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reports (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL,
+                natal_report TEXT NOT NULL,
+                fortune_report TEXT NOT NULL,
+                metadata TEXT NOT NULL
+            )
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO reports(created_at, natal_report, fortune_report, metadata)
+            VALUES(?, ?, ?, ?)
+            """,
+            (
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                natal_report,
+                fortune_report,
+                json.dumps(metadata, ensure_ascii=False),
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def main() -> None:
+    upload_path = simulate_upload()
+    print(f"[1/4] 문서 업로드 완료: {upload_path.resolve()}")
+
+    parsed_data = parse_saju_documents(upload_path)
+    print(f"[2/4] 문서 파싱 완료: {', '.join(parsed_data.keys())}")
+
+    print("[3/4] 사주 분석 실행...")
+    natal_report, fortune_report, metadata = build_saju(parsed_data)
+    print(natal_report)
+    print()
+    print(fortune_report)
+
+    print("[4/4] 결과를 DB에 저장합니다...")
+    store_reports(natal_report, fortune_report, metadata)
+    print(f"[4/4] 저장 완료: {DB_PATH.resolve()}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/saju_program/__init__.py
+++ b/saju_program/__init__.py
@@ -1,0 +1,27 @@
+"""saju_program 패키지 공개 인터페이스."""
+
+from .saju_core import (
+    EarthlyBranch,
+    Gungwi,
+    GungwiManager,
+    HeavenlyStem,
+    Pillar,
+    Shishin,
+    ShishinManager,
+)
+from .saju_fortune import SajuFortuneAnalyzer
+from .saju_model import Saju, SajuAnalyzer, parse_saju_documents
+
+__all__ = [
+    "EarthlyBranch",
+    "Gungwi",
+    "GungwiManager",
+    "HeavenlyStem",
+    "Pillar",
+    "Shishin",
+    "ShishinManager",
+    "Saju",
+    "SajuAnalyzer",
+    "SajuFortuneAnalyzer",
+    "parse_saju_documents",
+]

--- a/saju_program/rules_data.py
+++ b/saju_program/rules_data.py
@@ -1,0 +1,235 @@
+"""사주 분석에 사용되는 기본 규칙 데이터."""
+
+from __future__ import annotations
+
+ohaeng_order = ["목", "화", "토", "금", "수"]
+
+# --- 천간/지지 기본 데이터 -------------------------------------------------
+
+HEAVENLY_STEMS: dict[str, dict[str, str]] = {
+    "甲": {"ohaeng": "목", "yinyang": "양"},
+    "乙": {"ohaeng": "목", "yinyang": "음"},
+    "丙": {"ohaeng": "화", "yinyang": "양"},
+    "丁": {"ohaeng": "화", "yinyang": "음"},
+    "戊": {"ohaeng": "토", "yinyang": "양"},
+    "己": {"ohaeng": "토", "yinyang": "음"},
+    "庚": {"ohaeng": "금", "yinyang": "양"},
+    "辛": {"ohaeng": "금", "yinyang": "음"},
+    "壬": {"ohaeng": "수", "yinyang": "양"},
+    "癸": {"ohaeng": "수", "yinyang": "음"},
+}
+
+EARTHLY_BRANCHES: dict[str, dict[str, object]] = {
+    "子": {
+        "ohaeng": "수",
+        "yinyang": "양",
+        "gijeong": {"癸": {"ohaeng": "수", "yinyang": "음"}},
+    },
+    "丑": {
+        "ohaeng": "토",
+        "yinyang": "음",
+        "gijeong": {
+            "己": {"ohaeng": "토", "yinyang": "음"},
+            "癸": {"ohaeng": "수", "yinyang": "음"},
+            "辛": {"ohaeng": "금", "yinyang": "음"},
+        },
+    },
+    "寅": {
+        "ohaeng": "목",
+        "yinyang": "양",
+        "gijeong": {
+            "甲": {"ohaeng": "목", "yinyang": "양"},
+            "丙": {"ohaeng": "화", "yinyang": "양"},
+            "戊": {"ohaeng": "토", "yinyang": "양"},
+        },
+    },
+    "卯": {
+        "ohaeng": "목",
+        "yinyang": "음",
+        "gijeong": {
+            "乙": {"ohaeng": "목", "yinyang": "음"},
+        },
+    },
+    "辰": {
+        "ohaeng": "토",
+        "yinyang": "양",
+        "gijeong": {
+            "戊": {"ohaeng": "토", "yinyang": "양"},
+            "乙": {"ohaeng": "목", "yinyang": "음"},
+            "癸": {"ohaeng": "수", "yinyang": "음"},
+        },
+    },
+    "巳": {
+        "ohaeng": "화",
+        "yinyang": "음",
+        "gijeong": {
+            "丙": {"ohaeng": "화", "yinyang": "양"},
+            "戊": {"ohaeng": "토", "yinyang": "양"},
+            "庚": {"ohaeng": "금", "yinyang": "양"},
+        },
+    },
+    "午": {
+        "ohaeng": "화",
+        "yinyang": "양",
+        "gijeong": {
+            "丁": {"ohaeng": "화", "yinyang": "음"},
+            "己": {"ohaeng": "토", "yinyang": "음"},
+        },
+    },
+    "未": {
+        "ohaeng": "토",
+        "yinyang": "음",
+        "gijeong": {
+            "己": {"ohaeng": "토", "yinyang": "음"},
+            "丁": {"ohaeng": "화", "yinyang": "음"},
+            "乙": {"ohaeng": "목", "yinyang": "음"},
+        },
+    },
+    "申": {
+        "ohaeng": "금",
+        "yinyang": "양",
+        "gijeong": {
+            "庚": {"ohaeng": "금", "yinyang": "양"},
+            "壬": {"ohaeng": "수", "yinyang": "양"},
+            "戊": {"ohaeng": "토", "yinyang": "양"},
+        },
+    },
+    "酉": {
+        "ohaeng": "금",
+        "yinyang": "음",
+        "gijeong": {
+            "辛": {"ohaeng": "금", "yinyang": "음"},
+        },
+    },
+    "戌": {
+        "ohaeng": "토",
+        "yinyang": "양",
+        "gijeong": {
+            "戊": {"ohaeng": "토", "yinyang": "양"},
+            "辛": {"ohaeng": "금", "yinyang": "음"},
+            "丁": {"ohaeng": "화", "yinyang": "음"},
+        },
+    },
+    "亥": {
+        "ohaeng": "수",
+        "yinyang": "음",
+        "gijeong": {
+            "壬": {"ohaeng": "수", "yinyang": "양"},
+            "甲": {"ohaeng": "목", "yinyang": "양"},
+            "戊": {"ohaeng": "토", "yinyang": "양"},
+        },
+    },
+}
+
+# branch_hidden_stems는 지지별 지장간 이름만 필요한 경우를 위한 단축 데이터이다.
+branch_hidden_stems: dict[str, list[str]] = {
+    branch: list(data["gijeong"].keys()) for branch, data in EARTHLY_BRANCHES.items()
+}
+
+WUXING: dict[str, str] = {
+    **{name: info["ohaeng"] for name, info in HEAVENLY_STEMS.items()},
+    **{name: info["ohaeng"] for name, info in EARTHLY_BRANCHES.items()},
+}
+
+# --- 오행 상생/상극 및 십신 판정 규칙 --------------------------------------
+
+WUXING_RELATIONS = {
+    "목": {"생": "화", "극": "토", "피생": "수", "피극": "금"},
+    "화": {"생": "토", "극": "금", "피생": "목", "피극": "수"},
+    "토": {"생": "금", "극": "수", "피생": "화", "피극": "목"},
+    "금": {"생": "수", "극": "목", "피생": "토", "피극": "화"},
+    "수": {"생": "목", "극": "화", "피생": "금", "피극": "토"},
+}
+
+SIPSIN_MAP = {
+    ("비슷", "음양같음"): "비견",
+    ("비슷", "음양다름"): "겁재",
+    ("생", "음양같음"): "식신",
+    ("생", "음양다름"): "상관",
+    ("피생", "음양같음"): "편인",
+    ("피생", "음양다름"): "정인",
+    ("극", "음양같음"): "편재",
+    ("극", "음양다름"): "정재",
+    ("피극", "음양같음"): "편관",
+    ("피극", "음양다름"): "정관",
+}
+
+CHEYONG_GROUPS = {
+    "체": ["비견", "겁재", "정인", "편인"],
+    "용": ["정재", "편재", "정관", "편관"],
+    "중립": ["식신", "상관"],
+}
+
+MYOGO_BRANCHES = {"辰", "戌", "丑", "未"}
+
+# --- 지지 관계 (형충파해합) --------------------------------------------------
+
+CHONG = {("子", "午"), ("丑", "未"), ("寅", "申"), ("卯", "酉"), ("辰", "戌"), ("巳", "亥")}
+XING = {
+    ("子", "卯"),
+    ("丑", "戌"),
+    ("寅", "巳"),
+    ("卯", "子"),
+    ("辰", "辰"),
+    ("巳", "申"),
+    ("午", "午"),
+    ("未", "丑"),
+    ("申", "巳"),
+    ("酉", "酉"),
+    ("戌", "丑"),
+    ("亥", "亥"),
+}
+PO = {("子", "酉"), ("丑", "辰"), ("寅", "亥"), ("卯", "午"), ("巳", "申"), ("未", "戌")}
+CHUAN = {("子", "未"), ("丑", "午"), ("寅", "巳"), ("卯", "辰"), ("申", "亥"), ("酉", "戌")}
+HAP = {("子", "丑"), ("寅", "亥"), ("卯", "戌"), ("辰", "酉"), ("巳", "申"), ("午", "未")}
+SAMHAP = {
+    ("寅", "午", "戌"): "화",
+    ("巳", "酉", "丑"): "금",
+    ("申", "子", "辰"): "수",
+    ("亥", "卯", "未"): "목",
+}
+
+# --- 궁위 및 십신 기본 데이터 -----------------------------------------------
+
+DEFAULT_GUNGWI_DATA = {
+    "년주": {
+        "life_stage": "유년 시기 (1-18세)",
+        "representative_kin": "조상·부모·선배",
+        "symbolic_meaning": "근본, 태생 환경, 원거리",
+    },
+    "월주": {
+        "life_stage": "청년 시기 (18-35세)",
+        "representative_kin": "부모·형제·사회적 기반",
+        "symbolic_meaning": "출신 지역, 성장 배경",
+    },
+    "일주": {
+        "life_stage": "장년 시기 (35-55세)",
+        "representative_kin": "배우자·자아",
+        "symbolic_meaning": "개인 가치관, 생활 중심",
+    },
+    "시주": {
+        "life_stage": "말년 (55세 이후)",
+        "representative_kin": "자녀·후배",
+        "symbolic_meaning": "미래, 결과, 말년",
+    },
+}
+
+DEFAULT_SHISHIN_DATA = {
+    "비견": {"description": "자아, 동료, 평등 관계"},
+    "겁재": {"description": "경쟁, 공유, 돌파"},
+    "식신": {"description": "창조, 실행, 재능"},
+    "상관": {"description": "표현, 개혁, 돌출"},
+    "편재": {"description": "유동 자산, 기회"},
+    "정재": {"description": "축적 자산, 현실"},
+    "편관": {"description": "통제, 도전, 경쟁"},
+    "정관": {"description": "규범, 명예, 책임"},
+    "편인": {"description": "영감, 기획, 보호"},
+    "정인": {"description": "학습, 지원, 문서"},
+}
+
+# --- 공망 기본 구조 (문서 파서 확장 시 채워짐) ------------------------------
+
+GONGMANG_REFERENCE = {
+    # 문서 파서를 통해 추가 데이터를 병합하기 위한 기본 형태.
+    "설명": "공망은 특정 일주의 간지가 빠져 비어 있는 구간을 의미합니다.",
+}

--- a/saju_program/run_example.py
+++ b/saju_program/run_example.py
@@ -1,0 +1,75 @@
+"""예시 사주를 구성해 확장된 분석을 수행한다."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+from saju_program import rules_data
+from saju_program.saju_core import EarthlyBranch, GungwiManager, HeavenlyStem, Pillar, ShishinManager
+from saju_program.saju_fortune import SajuFortuneAnalyzer
+from saju_program.saju_model import Saju, SajuAnalyzer, parse_saju_documents
+
+
+def _prepare_sample_docs(base: pathlib.Path) -> pathlib.Path:
+    docs_dir = base / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    sample_md = docs_dir / "sample.md"
+    sample_md.write_text(
+        dedent(
+            """
+            # 사주 보조 규칙
+
+            체: 비견, 겁재, 정인
+            용: 정재, 편재, 정관
+            중립: 식신, 상관
+
+            공망 갑자: 갑자, 을축
+            공망 병인: 경신, 신유
+
+            묘고의 원칙
+            • 묘고는 형/충을 기뻐하며, 형/충이 없으면 묘가 된다.
+
+            허실 판단
+            • 지지가 뿌리가 되지 못하면 허투로 본다.
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return docs_dir
+
+
+def main() -> None:
+    with TemporaryDirectory() as tmp:
+        docs_dir = _prepare_sample_docs(pathlib.Path(tmp))
+        parsed_data = parse_saju_documents(docs_dir)
+
+        gungwi_manager = GungwiManager()
+        shishin_manager = ShishinManager(rules_data.DEFAULT_SHISHIN_DATA)
+
+        # 예시 사주 기둥 구성
+        year_pillar = Pillar(HeavenlyStem.from_name("丙"), EarthlyBranch.from_name("申"))
+        month_pillar = Pillar(HeavenlyStem.from_name("丙"), EarthlyBranch.from_name("申"))
+        day_pillar = Pillar(HeavenlyStem.from_name("辛"), EarthlyBranch.from_name("酉"))
+        time_pillar = Pillar(HeavenlyStem.from_name("丁"), EarthlyBranch.from_name("未"))
+
+        saju = Saju(year_pillar, month_pillar, day_pillar, time_pillar, gungwi_manager)
+        analyzer = SajuAnalyzer(saju, shishin_manager, parsed_data)
+        report = analyzer.generate_report()
+        print(report)
+
+        daewoon = Pillar(HeavenlyStem.from_name("己"), EarthlyBranch.from_name("丑"))
+        sewoon = Pillar(HeavenlyStem.from_name("丁"), EarthlyBranch.from_name("卯"))
+        fortune = SajuFortuneAnalyzer(saju, daewoon, sewoon)
+        print()
+        print(fortune.generate_report())
+
+
+if __name__ == "__main__":
+    main()

--- a/saju_program/saju_core.py
+++ b/saju_program/saju_core.py
@@ -1,0 +1,147 @@
+"""Core classes for Saju pillars, stems, branches, 궁위, and 십신."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from saju_program import rules_data
+
+
+@dataclass(frozen=True, slots=True)
+class HeavenlyStem:
+    """Represents a single 천간 with its 오행과 음양 정보."""
+
+    name: str
+    ohaeng: str
+    yinyang: str
+
+    @classmethod
+    def from_name(cls, name: str) -> "HeavenlyStem":
+        try:
+            data = rules_data.HEAVENLY_STEMS[name]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"알 수 없는 천간: {name}") from exc
+        return cls(name=name, ohaeng=data["ohaeng"], yinyang=data["yinyang"])
+
+    def __repr__(self) -> str:  # pragma: no cover - string formatting helper
+        return f"{self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class EarthlyBranch:
+    """Represents a single 지지 with 오행, 음양 및 지장간 정보."""
+
+    name: str
+    ohaeng: str
+    yinyang: str
+    gijeong: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_name(cls, name: str) -> "EarthlyBranch":
+        try:
+            data = rules_data.EARTHLY_BRANCHES[name]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"알 수 없는 지지: {name}") from exc
+        return cls(
+            name=name,
+            ohaeng=data["ohaeng"],
+            yinyang=data["yinyang"],
+            gijeong=data.get("gijeong", {}),
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - string formatting helper
+        return f"{self.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class Gungwi:
+    """궁위(宮位)에 대한 이름, 대표 육친, 상징 의미를 관리한다."""
+
+    name: str
+    representative_kin: str
+    symbolic_meaning: str
+    life_stage: str | None = None
+
+    def __repr__(self) -> str:  # pragma: no cover - string formatting helper
+        return f"{self.name}({self.representative_kin})"
+
+
+@dataclass(slots=True)
+class Pillar:
+    """천간과 지지, 선택적으로 궁위를 포함한 한 기둥."""
+
+    stem: HeavenlyStem
+    branch: EarthlyBranch
+    gungwi: Gungwi | None = None
+
+    def __repr__(self) -> str:  # pragma: no cover - formatting helper
+        if self.gungwi:
+            return f"{self.stem}{self.branch}({self.gungwi.name})"
+        return f"{self.stem}{self.branch}"
+
+    @property
+    def hidden_stem_names(self) -> list[str]:
+        """Return the list of 지장간 names for this pillar's 지지."""
+
+        return list(self.branch.gijeong.keys())
+
+    def has_root(self) -> bool:
+        """Check if the pillar's stem has a root within the branch's 지장간."""
+
+        for hidden in self.branch.gijeong.values():
+            if hidden["ohaeng"] == self.stem.ohaeng:
+                return True
+        return False
+
+
+class GungwiManager:
+    """년·월·일·시주 궁위를 기본 매핑과 함께 제공한다."""
+
+    def __init__(self, custom_data: dict[str, dict[str, str]] | None = None):
+        source = custom_data or rules_data.DEFAULT_GUNGWI_DATA
+        self.gungwi_map: dict[str, Gungwi] = {
+            name: Gungwi(
+                name=name,
+                representative_kin=info["representative_kin"],
+                symbolic_meaning=info["symbolic_meaning"],
+                life_stage=info.get("life_stage"),
+            )
+            for name, info in source.items()
+        }
+
+    def get_gungwi(self, name: str) -> Gungwi | None:
+        return self.gungwi_map.get(name)
+
+
+@dataclass(frozen=True, slots=True)
+class Shishin:
+    """십신 단일 항목. 설명과 십신 간 관계를 포함한다."""
+
+    name: str
+    description: str
+    relations: dict[str, str] = field(default_factory=dict)
+
+    def relation_to(self, other: str) -> str:
+        return self.relations.get(other, "관계 없음")
+
+
+class ShishinManager:
+    """십신 데이터를 이름으로 조회하는 간단한 컨테이너."""
+
+    def __init__(self, data: dict[str, dict[str, object]] | None = None):
+        raw = data or rules_data.DEFAULT_SHISHIN_DATA
+        self._shishins = {
+            name: Shishin(
+                name=name,
+                description=info.get("description", ""),
+                relations=info.get("relations", {}),
+            )
+            for name, info in raw.items()
+        }
+
+    def get_shishin(self, name: str) -> Shishin | None:
+        return self._shishins.get(name)
+
+    def known(self) -> Iterable[str]:  # pragma: no cover - convenience
+        return self._shishins.keys()

--- a/saju_program/saju_fortune.py
+++ b/saju_program/saju_fortune.py
@@ -1,0 +1,92 @@
+"""대운/세운 분석기."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+from saju_program import rules_data
+from saju_program.saju_core import Pillar
+
+
+class SajuFortuneAnalyzer:
+    """원국과 운세 기둥을 비교하여 합·충·형·파·삼합 등을 탐지한다."""
+
+    def __init__(self, saju, daewoon: Pillar, sewoon: Pillar):
+        self.saju = saju
+        self.daewoon = daewoon
+        self.sewoon = sewoon
+
+    def generate_report(self) -> str:
+        lines: list[str] = ["--- 대운/세운 분석 ---"]
+        lines.append(f"대운: {self.daewoon}")
+        lines.extend(self._describe_fortune_interaction(self.daewoon, "대운"))
+        lines.append("")
+        lines.append(f"세운: {self.sewoon}")
+        lines.extend(self._describe_fortune_interaction(self.sewoon, "세운"))
+        samhap_lines = self._detect_samhap()
+        if samhap_lines:
+            lines.append("")
+            lines.append("삼합·삼형성 체크")
+            lines.extend(samhap_lines)
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    def _describe_fortune_interaction(self, fortune_pillar: Pillar, label: str) -> list[str]:
+        results: list[str] = []
+        natal_branches = [pillar.branch.name for pillar in self.saju.get_pillars()]
+        natal_stems = [pillar.stem.name for pillar in self.saju.get_pillars()]
+
+        branch_message = self._check_branch_relations(fortune_pillar.branch.name, natal_branches, label)
+        if branch_message:
+            results.extend(branch_message)
+        stem_message = self._check_stem_presence(fortune_pillar.stem.name, natal_stems, label)
+        if stem_message:
+            results.append(stem_message)
+        myogo_message = self._check_myogo(fortune_pillar.branch.name)
+        if myogo_message:
+            results.append(myogo_message)
+        if not results:
+            results.append("  - 특이 관계가 감지되지 않았습니다.")
+        return results
+
+    def _check_branch_relations(self, branch: str, natal_branches: list[str], label: str) -> list[str]:
+        messages: list[str] = []
+        for natal in natal_branches:
+            pair = (branch, natal)
+            if self._pair_contains(rules_data.CHONG, *pair):
+                messages.append(f"  - {label} 지지 {branch} ↔ {natal}: 충(沖)으로 변동·이별 신호")
+            elif self._pair_contains(rules_data.XING, *pair):
+                messages.append(f"  - {label} 지지 {branch} ↔ {natal}: 형(刑)으로 갈등·법적 이슈")
+            elif self._pair_contains(rules_data.PO, *pair):
+                messages.append(f"  - {label} 지지 {branch} ↔ {natal}: 파(破)로 손실·균열 가능성")
+            elif self._pair_contains(rules_data.CHUAN, *pair):
+                messages.append(f"  - {label} 지지 {branch} ↔ {natal}: 천(穿)으로 강한 제압수단")
+            elif self._pair_contains(rules_data.HAP, *pair):
+                messages.append(f"  - {label} 지지 {branch} ↔ {natal}: 합(合)으로 협력·결속")
+        return messages
+
+    def _check_stem_presence(self, stem: str, natal_stems: list[str], label: str) -> str | None:
+        if stem in natal_stems:
+            return f"  - {label} 천간 {stem}: 원국과 동일하여 기질이 증폭됩니다."
+        return None
+
+    def _check_myogo(self, branch: str) -> str | None:
+        if branch in rules_data.MYOGO_BRANCHES:
+            return f"  - 지지 {branch}: 묘고(墓庫) 기운 활성화 가능, 형/충 여부를 확인하세요."
+        return None
+
+    def _detect_samhap(self) -> list[str]:
+        branches = [pillar.branch.name for pillar in self.saju.get_pillars()]
+        branches.extend([self.daewoon.branch.name, self.sewoon.branch.name])
+        matches: list[str] = []
+        for combo in combinations(branches, 3):
+            for target, element in rules_data.SAMHAP.items():
+                if set(combo) == set(target):
+                    matches.append(
+                        f"  - {'/'.join(combo)}: 삼합 완성 → {element.upper()} 기운 강화"
+                    )
+        return matches
+
+    @staticmethod
+    def _pair_contains(pair_set: set[tuple[str, str]], a: str, b: str) -> bool:
+        return (a, b) in pair_set or (b, a) in pair_set

--- a/saju_program/saju_model.py
+++ b/saju_program/saju_model.py
@@ -1,0 +1,281 @@
+"""Saju 모델, 문서 파서, 그리고 종합 분석기를 정의한다."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Iterable
+
+from saju_program import rules_data
+from saju_program.saju_core import (
+    EarthlyBranch,
+    GungwiManager,
+    HeavenlyStem,
+    Pillar,
+    ShishinManager,
+)
+
+
+def parse_saju_documents(folder_path: str | Path) -> dict[str, object]:
+    """Parse markdown/txt 문서를 스캔하여 분석 보조 데이터를 수집한다."""
+
+    path = Path(folder_path)
+    parsed = {
+        "myogo_rules": {},
+        "heosil_rules": {},
+        "cheyong_sipsin": {},
+        "gongmang": {},
+    }
+    if not path.exists():
+        return parsed
+
+    for file in path.iterdir():
+        if file.suffix.lower() not in {".md", ".txt"}:
+            continue
+        content = file.read_text(encoding="utf-8")
+        parsed["myogo_rules"][file.name] = _parse_bullets(content, r"묘고[\s\S]*?\n(.*?)\n\n")
+        parsed["heosil_rules"][file.name] = _parse_bullets(content, r"허실[\s\S]*?\n(.*?)\n\n")
+        parsed["cheyong_sipsin"].update(_parse_cheyong(content))
+        parsed["gongmang"].update(_parse_gongmang(content))
+    return parsed
+
+
+def _parse_bullets(content: str, pattern: str) -> list[str]:
+    block = re.search(pattern, content)
+    if not block:
+        return []
+    return [line.strip("• ●-* ") for line in block.group(1).splitlines() if line.strip()]
+
+
+def _parse_cheyong(content: str) -> dict[str, list[str]]:
+    match = re.search(r"체\s*:?\s*(.*?)\n용\s*:?\s*(.*?)\n중립\s*:?\s*(.*?)\n", content)
+    if not match:
+        return {}
+    return {
+        "체": [s.strip() for s in match.group(1).split(',') if s.strip()],
+        "용": [s.strip() for s in match.group(2).split(',') if s.strip()],
+        "중립": [s.strip() for s in match.group(3).split(',') if s.strip()],
+    }
+
+
+def _parse_gongmang(content: str) -> dict[str, list[str]]:
+    results: dict[str, list[str]] = {}
+    for line in content.splitlines():
+        if "공망" not in line:
+            continue
+        parts = re.split(r"[:：]", line, maxsplit=1)
+        if len(parts) != 2:
+            continue
+        key = parts[0].replace("공망", "").strip()
+        targets = [item.strip() for item in parts[1].split(',') if item.strip()]
+        if key:
+            results[key] = targets
+    return results
+
+
+@dataclass
+class Saju:
+    """년·월·일·시주 네 기둥으로 구성된 사주 객체."""
+
+    year: Pillar
+    month: Pillar
+    day: Pillar
+    time: Pillar
+
+    def __init__(self, year: Pillar, month: Pillar, day: Pillar, time: Pillar, gungwi_manager: GungwiManager):
+        self.year = year
+        self.month = month
+        self.day = day
+        self.time = time
+
+        self.year.gungwi = gungwi_manager.get_gungwi("년주")
+        self.month.gungwi = gungwi_manager.get_gungwi("월주")
+        self.day.gungwi = gungwi_manager.get_gungwi("일주")
+        self.time.gungwi = gungwi_manager.get_gungwi("시주")
+
+    def get_pillars(self) -> list[Pillar]:
+        return [self.year, self.month, self.day, self.time]
+
+    def get_stems(self) -> list[HeavenlyStem]:
+        return [pillar.stem for pillar in self.get_pillars()]
+
+    def get_branches(self) -> list[EarthlyBranch]:
+        return [pillar.branch for pillar in self.get_pillars()]
+
+    def __repr__(self) -> str:  # pragma: no cover - formatting helper
+        return f"사주: {self.year}, {self.month}, {self.day}, {self.time}"
+
+
+class SajuAnalyzer:
+    """궁위·십신·지지관계·묘고 등을 종합 분석한다."""
+
+    def __init__(self, saju: Saju, shishin_manager: ShishinManager, parsed_data: dict[str, object] | None = None):
+        self.saju = saju
+        self.shishin_manager = shishin_manager
+        self.parsed_data = parsed_data or {}
+
+    def generate_report(self) -> str:
+        sections = [
+            self._render_gungwi_section(),
+            self._render_sipsin_section(),
+            self._render_branch_relations_section(),
+            self._render_cheyong_section(),
+            self._render_advanced_rules_section(),
+            self._render_gongmang_section(),
+        ]
+        return "\n\n".join(section for section in sections if section)
+
+    # --- 궁위 분석 ---------------------------------------------------------
+    def _render_gungwi_section(self) -> str:
+        lines = ["--- 궁위 분석 ---"]
+        for pillar in self.saju.get_pillars():
+            if not pillar.gungwi:
+                continue
+            lines.append(f"{pillar} : {pillar.gungwi.life_stage}")
+            lines.append(f"  - 대표 육친: {pillar.gungwi.representative_kin}")
+            lines.append(f"  - 상징 의미: {pillar.gungwi.symbolic_meaning}")
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    # --- 십신 분석 ---------------------------------------------------------
+    def _render_sipsin_section(self) -> str:
+        lines = ["--- 십신 분석 ---"]
+        ilgan = self.saju.day.stem
+        for pillar in self.saju.get_pillars():
+            sipsin_name = self._calculate_sipsin(ilgan, pillar.stem)
+            shishin = self.shishin_manager.get_shishin(sipsin_name)
+            descriptor = shishin.description if shishin else "정의되지 않음"
+            if pillar.stem.name == ilgan.name:
+                lines.append(f"{pillar}: 일간")
+            else:
+                lines.append(f"{pillar}: {sipsin_name} ({descriptor})")
+            if pillar.has_root():
+                lines.append("  - 지지에 뿌리가 있어 실(實)함")
+            else:
+                lines.append("  - 지지에 뿌리가 없어 허투(虛透)")
+            if pillar.branch.gijeong:
+                for name, info in pillar.branch.gijeong.items():
+                    hidden = HeavenlyStem(name, info["ohaeng"], info["yinyang"])
+                    hidden_sipsin = self._calculate_sipsin(ilgan, hidden)
+                    lines.append(f"    · 지장간 {name}: {hidden_sipsin}")
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    def _calculate_sipsin(self, ilgan: HeavenlyStem, target: HeavenlyStem) -> str:
+        if ilgan.name == target.name:
+            return "일간"
+        relation = "비슷"
+        ilgan_rel = rules_data.WUXING_RELATIONS[ilgan.ohaeng]
+        if ilgan_rel["생"] == target.ohaeng:
+            relation = "생"
+        elif ilgan_rel["극"] == target.ohaeng:
+            relation = "극"
+        elif ilgan_rel["피생"] == target.ohaeng:
+            relation = "피생"
+        elif ilgan_rel["피극"] == target.ohaeng:
+            relation = "피극"
+        yin_relation = "음양같음" if ilgan.yinyang == target.yinyang else "음양다름"
+        return rules_data.SIPSIN_MAP.get((relation, yin_relation), "미분류")
+
+    # --- 지지 관계 ---------------------------------------------------------
+    def _render_branch_relations_section(self) -> str:
+        lines = ["--- 지지 합·충·형·파·천 ---"]
+        branch_names = [branch.name for branch in self.saju.get_branches()]
+        relations_found = False
+        for i, first in enumerate(branch_names):
+            for second in branch_names[i + 1 :]:
+                relation = self._branch_relation(first, second)
+                if relation:
+                    lines.append(f"  - {first} ↔ {second}: {relation}")
+                    relations_found = True
+        if not relations_found:
+            lines.append("  - 특별한 지지 관계가 없습니다.")
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    def _branch_relation(self, a: str, b: str) -> str | None:
+        if self._pair_contains(rules_data.CHONG, a, b):
+            return "충(沖): 충돌·변화"
+        if self._pair_contains(rules_data.XING, a, b):
+            return "형(刑): 갈등·압박"
+        if self._pair_contains(rules_data.PO, a, b):
+            return "파(破): 균열·손실"
+        if self._pair_contains(rules_data.CHUAN, a, b):
+            return "천(穿): 강한 제압수단"
+        if self._pair_contains(rules_data.HAP, a, b):
+            return "합(合): 결속·협력"
+        return None
+
+    # --- 체용 및 주빈 ------------------------------------------------------
+    def _render_cheyong_section(self) -> str:
+        lines = ["--- 체용/주빈 분석 ---"]
+        ilgan = self.saju.day.stem
+        cheyong_map = self.parsed_data.get("cheyong_sipsin") or rules_data.CHEYONG_GROUPS
+        for pillar in self.saju.get_pillars():
+            sipsin = self._calculate_sipsin(ilgan, pillar.stem)
+            category = self._resolve_cheyong_category(sipsin, cheyong_map)
+            lines.append(f"{pillar.stem.name}: {sipsin} → {category}")
+        lines.append("")
+        lines.append("주위(主位): 일간·일주·시주")
+        lines.append("빈위(賓位): 년주·월주")
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    def _resolve_cheyong_category(self, sipsin: str, cheyong_map: dict[str, Iterable[str]]) -> str:
+        for category, values in cheyong_map.items():
+            if sipsin in values:
+                return category
+        return "중립"
+
+    # --- 허실·묘고 등 ------------------------------------------------------
+    def _render_advanced_rules_section(self) -> str:
+        lines = ["--- 허실·묘고 분석 ---"]
+        for pillar in self.saju.get_pillars():
+            status = "실(實)" if pillar.has_root() else "허(虛)"
+            lines.append(f"{pillar}: {status} 상태")
+        myogo_lines = self._detect_myogo()
+        if myogo_lines:
+            lines.extend(myogo_lines)
+        else:
+            lines.append("묘고 지지가 없습니다.")
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    def _detect_myogo(self) -> list[str]:
+        results: list[str] = []
+        branch_names = [branch.name for branch in self.saju.get_branches()]
+        for branch in branch_names:
+            if branch not in rules_data.MYOGO_BRANCHES:
+                continue
+            interaction = any(
+                self._pair_contains(rules_data.CHONG, branch, other)
+                or self._pair_contains(rules_data.XING, branch, other)
+                for other in branch_names
+                if other != branch
+            )
+            state = "庫(고)로 작동" if interaction else "墓(묘)로 잠김"
+            results.append(f"  - {branch}: 묘고 지지 → {state}")
+        return results
+
+    # --- 공망 분석 ---------------------------------------------------------
+    def _render_gongmang_section(self) -> str:
+        lines = ["--- 공망 분석 ---"]
+        gongmang_map: dict[str, list[str]] = self.parsed_data.get("gongmang", {})  # type: ignore[arg-type]
+        if not gongmang_map:
+            lines.append("공망 정보가 제공되지 않았습니다.")
+        else:
+            pillars = self.saju.get_pillars()
+            all_names = [p.stem.name + p.branch.name for p in pillars]
+            for key, empties in gongmang_map.items():
+                hits = [name for name in all_names if name in empties]
+                if hits:
+                    lines.append(f"  - {key}: 사주에 {', '.join(hits)} 공망 발생")
+                else:
+                    lines.append(f"  - {key}: 해당 공망 없음")
+        lines.append("-" * 20)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _pair_contains(pair_set: set[tuple[str, str]], a: str, b: str) -> bool:
+        return (a, b) in pair_set or (b, a) in pair_set


### PR DESCRIPTION
## Summary
- expand the shared 규칙 데이터 to include 천간·지지 속성, 오행 상생·상극, 형충파해/삼합, 궁위·십신 기본값까지 통합했습니다.
- rebuild the core dataclasses and 종합 사주 분석기로 궁위, 십신 허실, 지지 관계, 체용·묘고·공망 등을 리포트하도록 했습니다.
- upgrade the 대운·세운 분석기에 합·충·형·파·삼합 감지를 추가하고, 예제 실행/메인 파이프라인에서 문서 파싱→분석→DB 저장 흐름을 완성했습니다.

## Testing
- `python saju_program/run_example.py`
- `python Main.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5697a37148330a692cba599174018