### PR TITLE
Handle OpenAI rate limit errors gracefully

### DIFF
--- a/streamlit_app_fixed/core/ai_utils.py
+++ b/streamlit_app_fixed/core/ai_utils.py
@@ -1,9 +1,25 @@
 # core/ai_utils.py
 import os
 import logging
-from openai import OpenAI
 from functools import lru_cache
+from typing import Optional, Tuple
+
 import streamlit as st
+
+from openai import OpenAI
+
+try:  # 최신 OpenAI SDK (>=1.0)
+    from openai import AuthenticationError, APIConnectionError, APIError
+    from openai import RateLimitError as _RateLimitError
+except ImportError:  # 구버전 호환
+    from openai.error import (  # type: ignore[no-redef]
+        AuthenticationError,
+        APIConnectionError,
+        OpenAIError as APIError,
+        RateLimitError as _RateLimitError,
+    )
+
+RATE_LIMIT_ERRORS: Tuple[type, ...] = (_RateLimitError,) if "_RateLimitError" in locals() else tuple()
 
 # -------------------------
 # 내부 유틸
@@ -25,6 +41,73 @@ def _load_api_key() -> str:
     if secret_key:
         return secret_key
     return os.getenv("OPENAI_API_KEY")
+
+
+def _notify_streamlit(message: str, level: str = "warning", key: Optional[str] = None) -> None:
+    """Streamlit UI에 중복 없이 경고 메시지를 띄운다."""
+
+    if not hasattr(st, "session_state"):
+        return
+
+    if key:
+        session_key = f"ai_utils_notice_{key}"
+        if st.session_state.get(session_key):
+            return
+        st.session_state[session_key] = True
+
+    display = getattr(st, level, None)
+    if callable(display):
+        try:
+            display(message)
+        except Exception:  # UI 경고 실패는 무시
+            logging.debug("Streamlit 알림 표시 실패", exc_info=True)
+
+
+def _handle_openai_error(exc: Exception, context: str) -> None:
+    """OpenAI 호출 실패 시 사용자 친화적 메시지와 로그를 남긴다."""
+
+    error_message = f"⚠️ {context} 실패: {exc}"
+    logging.warning(error_message)
+
+    if RATE_LIMIT_ERRORS and isinstance(exc, RATE_LIMIT_ERRORS):
+        _notify_streamlit(
+            "OpenAI API 사용량 한도가 초과되어 교정을 건너뜁니다. 관리자에게 문의해 주세요.",
+            level="warning",
+            key="rate_limit",
+        )
+        return
+
+    if isinstance(exc, AuthenticationError):
+        _notify_streamlit(
+            "OpenAI API 키 인증에 실패했습니다. 환경 변수를 다시 확인해 주세요.",
+            level="error",
+            key="auth_error",
+        )
+        return
+
+    if isinstance(exc, APIConnectionError):
+        _notify_streamlit(
+            "OpenAI API와 통신할 수 없습니다. 네트워크 상태를 확인하거나 잠시 후 다시 시도해 주세요.",
+            level="warning",
+            key="connection_error",
+        )
+        return
+
+    if isinstance(exc, APIError):
+        code = getattr(exc, "code", None)
+        if code == "insufficient_quota":
+            _notify_streamlit(
+                "OpenAI 요금제가 소진되어 교정 기능을 중단합니다. 관리자가 결제를 갱신해야 합니다.",
+                level="error",
+                key="insufficient_quota",
+            )
+            return
+
+    _notify_streamlit(
+        "OpenAI 교정 기능에서 오류가 발생하여 원문을 그대로 사용합니다.",
+        level="warning",
+        key="generic_error",
+    )
 
 @lru_cache(maxsize=1)
 def _get_openai_client() -> OpenAI:
@@ -68,6 +151,6 @@ def clean_text_with_ai(text: str, max_tokens: int = 1000, model: str = "gpt-4o-m
             max_tokens=max_tokens,
         )
         return response.choices[0].message.content.strip()
-    except Exception as exc:
-        logging.warning(f"⚠️ clean_text_with_ai 실패: {exc}")
+    except Exception as exc:  # pragma: no cover - 네트워크 오류 대응
+        _handle_openai_error(exc, "clean_text_with_ai")
         return text  # 실패하면 원문 그대로 반환


### PR DESCRIPTION
## Summary
- add robust OpenAI exception handling so rate limit and quota errors no longer crash the cleaner
- surface user-friendly Streamlit alerts when OpenAI connectivity, auth, or quota issues occur while falling back to raw text

## Testing
- python -m compileall core/ai_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e5d779c483309c0259823884dc2a